### PR TITLE
Changed the way the rows are selected in gcode_tw table widget. Click…

### DIFF
--- a/src/TheAntFarm/ui_manager/ui_control_tab.py
+++ b/src/TheAntFarm/ui_manager/ui_control_tab.py
@@ -1,4 +1,4 @@
-from PySide6.QtCore import Signal, Slot, QObject, QSize, Qt, QPersistentModelIndex
+from PySide6.QtCore import Signal, Slot, QObject, QSize, Qt, QPersistentModelIndex, QItemSelectionModel
 from PySide6.QtWidgets import QFileDialog, QLabel, QRadioButton, QHeaderView, QButtonGroup, QAbstractItemView
 from PySide6.QtGui import QIcon
 from style_manager import StyleManager
@@ -182,11 +182,9 @@ class UiControlTab(QObject):
         self.ui.gcode_tw.horizontalHeader().setSectionResizeMode(0, QHeaderView.Fixed)
         self.ui.gcode_tw.setColumnWidth(1, 100)
         self.ui.gcode_tw.horizontalHeader().setSectionResizeMode(1, QHeaderView.Stretch)
-        # To Select Rows by Vertical Header
+        # To Select Rows by clicking column 0 (filename) only, not column 1 (radio button)
         self.ui.gcode_tw.setSelectionMode(QAbstractItemView.NoSelection)
-        self.ui.gcode_tw.horizontalHeader().sectionPressed.disconnect()
-        self.ui.gcode_tw.verticalHeader().sectionClicked.connect(self.select_gcode_row)
-        self.ui.gcode_tw.verticalHeader().sectionDoubleClicked.connect(self.deselect_all_gcode_row)
+        self.ui.gcode_tw.cellClicked.connect(self._handle_table_cell_click)
 
         self.ui.upload_temp_tb.clicked.connect(self.update_temporary_gcode_files)
         self.ui.remove_gcode_tb.clicked.connect(self.remove_gcode_files)
@@ -243,23 +241,28 @@ class UiControlTab(QObject):
         self.ui.zero_xy_pb.setEnabled(enable_flag)
 
     def deselect_all_gcode_row(self):
-        self.ui.gcode_tw.setSelectionMode(QAbstractItemView.MultiSelection)
-        self.ui.gcode_tw.setSelectionBehavior(QAbstractItemView.SelectRows)
+        """Clear all selections"""
         self.ui.gcode_tw.clearSelection()
-        self.ui.gcode_tw.setSelectionMode(QAbstractItemView.NoSelection)
 
     def select_gcode_row(self, index):
-        self.ui.gcode_tw.setSelectionMode(QAbstractItemView.MultiSelection)
-        self.ui.gcode_tw.setSelectionBehavior(QAbstractItemView.SelectRows)
-        qindexes = self.ui.gcode_tw.selectionModel().selectedRows()
-        indexes = [x.row() for x in qindexes]
-        if index in indexes:
-            selectionModel = self.ui.gcode_tw.selectionModel()
+        """Toggle row selection - deselect only the clicked row if selected, or select it if not"""
+        selected_rows = [idx.row() for idx in self.ui.gcode_tw.selectionModel().selectedRows()]
+        selectionModel = self.ui.gcode_tw.selectionModel()
+        if index in selected_rows:
+            # Deselect only this row, keep others selected
             selectionModel.select(self.ui.gcode_tw.model().index(index, 0),
-                                  selectionModel.Deselect | selectionModel.Rows)
+                                  QItemSelectionModel.Deselect | QItemSelectionModel.Rows)
         else:
             self.ui.gcode_tw.selectRow(index)
-        self.ui.gcode_tw.setSelectionMode(QAbstractItemView.NoSelection)
+
+    def _handle_table_cell_click(self, row, column):
+        """Only select row when clicking column 0 (filename), ignore column 1 (radio button)"""
+        if column == 0:
+            # Enable selection mode temporarily to select the row
+            self.ui.gcode_tw.setSelectionMode(QAbstractItemView.MultiSelection)
+            self.ui.gcode_tw.setSelectionBehavior(QAbstractItemView.SelectRows)
+            self.select_gcode_row(row)
+            self.ui.gcode_tw.setSelectionMode(QAbstractItemView.NoSelection)
 
     def init_xy_jog_step_value(self):
         """ Initialize XY step and value ui fields. """

--- a/tests/unit/test_ui_control_tab.py
+++ b/tests/unit/test_ui_control_tab.py
@@ -1,0 +1,138 @@
+"""
+Test suite for UI Control Tab selection functionality.
+Tests focus on the simplified gcode table row selection behavior.
+"""
+
+import pytest
+from unittest.mock import Mock, patch
+from PySide6.QtWidgets import QApplication, QAbstractItemView
+
+
+@pytest.fixture
+def qapp():
+    """Create QApplication if it doesn't exist"""
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+class TestSelectGcodeRowImplementation:
+    """Test select_gcode_row method logic"""
+    
+    def test_select_row_when_not_selected(self, qapp):
+        """Verify selecting row when not selected"""
+        mock_ui = Mock()
+        mock_ui.gcode_tw = Mock()
+        mock_selection_model = Mock()
+        mock_selection_model.selectedRows.return_value = []  # No rows selected
+        mock_ui.gcode_tw.selectionModel.return_value = mock_selection_model
+        
+        from TheAntFarm.ui_manager.ui_control_tab import UiControlTab
+        
+        # Create partial instance for method testing
+        ui_tab = UiControlTab.__new__(UiControlTab)
+        ui_tab.ui = mock_ui
+        
+        # Call method
+        ui_tab.select_gcode_row(0)
+        
+        # Verify selectRow was called
+        mock_ui.gcode_tw.selectRow.assert_called_once_with(0)
+    
+    def test_deselect_single_row_when_selected(self, qapp):
+        """Verify deselecting only the clicked row when it's selected"""
+        from unittest.mock import MagicMock
+        mock_ui = Mock()
+        mock_ui.gcode_tw = Mock()
+        
+        # Mock a selected row at index 0
+        mock_index = Mock()
+        mock_index.row.return_value = 0
+        mock_selection_model = MagicMock()
+        mock_selection_model.selectedRows.return_value = [mock_index]  # Row 0 is selected
+        mock_ui.gcode_tw.selectionModel.return_value = mock_selection_model
+        mock_ui.gcode_tw.model.return_value = Mock()
+        
+        from TheAntFarm.ui_manager.ui_control_tab import UiControlTab
+        
+        # Create partial instance for method testing
+        ui_tab = UiControlTab.__new__(UiControlTab)
+        ui_tab.ui = mock_ui
+        
+        # Call method
+        ui_tab.select_gcode_row(0)
+        
+        # Verify selectionModel.select was called with Deselect flag
+        mock_selection_model.select.assert_called_once()
+        # Verify clearSelection was NOT called (only this row should be deselected)
+        mock_ui.gcode_tw.clearSelection.assert_not_called()
+
+
+class TestDeselectAllGcodeRowImplementation:
+    """Test deselect_all_gcode_row method logic"""
+    
+    def test_clears_selection(self, qapp):
+        """Verify clearSelection is called"""
+        mock_ui = Mock()
+        mock_ui.gcode_tw = Mock()
+        
+        from TheAntFarm.ui_manager.ui_control_tab import UiControlTab
+        
+        # Create partial instance for method testing
+        ui_tab = UiControlTab.__new__(UiControlTab)
+        ui_tab.ui = mock_ui
+        
+        # Call method
+        ui_tab.deselect_all_gcode_row()
+        
+        # Verify clearSelection was called
+        mock_ui.gcode_tw.clearSelection.assert_called_once()
+
+
+class TestSelectMethodCodeQuality:
+    """Test code quality and simplification of selection methods"""
+    
+    def test_select_gcode_row_no_mode_switching(self, qapp):
+        """Verify select_gcode_row doesn't use setSelectionMode"""
+        from TheAntFarm.ui_manager.ui_control_tab import UiControlTab
+        import inspect
+        
+        source = inspect.getsource(UiControlTab.select_gcode_row)
+        
+        # Should not contain mode switching - this proves simplification
+        assert "setSelectionMode" not in source, \
+            "select_gcode_row should not switch modes"
+        assert "setSelectionBehavior" not in source, \
+            "select_gcode_row should not set behavior"
+    
+    def test_deselect_all_gcode_row_no_mode_switching(self, qapp):
+        """Verify deselect_all_gcode_row doesn't use setSelectionMode"""
+        from TheAntFarm.ui_manager.ui_control_tab import UiControlTab
+        import inspect
+        
+        source = inspect.getsource(UiControlTab.deselect_all_gcode_row)
+        
+        # Should not contain mode switching - this proves simplification
+        assert "setSelectionMode" not in source, \
+            "deselect_all_gcode_row should not switch modes"
+        assert "setSelectionBehavior" not in source, \
+            "deselect_all_gcode_row should not set behavior"
+
+
+class TestInitialization:
+    """Test initialization configuration"""
+    
+    def test_multiselection_mode_configured(self, qapp):
+        """Verify NoSelection mode is used with cellClicked handler for column 0 only"""
+        from TheAntFarm.ui_manager.ui_control_tab import UiControlTab
+        import inspect
+        
+        source = inspect.getsource(UiControlTab.__init__)
+        
+        # Check for NoSelection mode (to prevent default row selection on any click)
+        assert "QAbstractItemView.NoSelection" in source, \
+            "NoSelection mode should be configured"
+        # Check that cellClicked is connected (for custom column-specific selection)
+        assert "cellClicked.connect(self._handle_table_cell_click)" in source, \
+            "cellClicked should be connected to _handle_table_cell_click"


### PR DESCRIPTION
Improved the way item are selected in the gcode table. Clicking on item name selects/deselects the row, clicking on radio button has no effect on row selection, it only selects gcode visualization. Clicking on the vertical header number has no effect (differently from before).