### PR TITLE
Reorganized sender tab

### DIFF
--- a/src/TheAntFarm/settings_manager/settings_app.py
+++ b/src/TheAntFarm/settings_manager/settings_app.py
@@ -20,6 +20,7 @@ class AppSettingsHandler:
     MAIN_TAB_INDEX_DEFAULT = 0
     CTRL_TAB_INDEX_DEFAULT = 0
     SETTINGS_TAB_INDEX_DEFAULT = 0
+    JOG_PROBE_TAB_INDEX_DEFAULT = 0
     SHOW_ALIGN_TAB_DEFAULT = False
     SHOW_SETTINGS_TAB_DEFAULT = False
     SHOW_CONSOLE_DEFAULT = False
@@ -75,6 +76,7 @@ class AppSettingsHandler:
         self.main_tab_index = self.MAIN_TAB_INDEX_DEFAULT
         self.ctrl_tab_index = self.CTRL_TAB_INDEX_DEFAULT
         self.settings_tab_index = self.SETTINGS_TAB_INDEX_DEFAULT
+        self.jog_probe_tab_index = self.JOG_PROBE_TAB_INDEX_DEFAULT
         self.align_tab_visibility = self.SHOW_ALIGN_TAB_DEFAULT
         self.settings_tab_visibility = self.SHOW_SETTINGS_TAB_DEFAULT
         self.console_visibility = self.SHOW_CONSOLE_DEFAULT
@@ -170,6 +172,7 @@ class AppSettingsHandler:
             self.main_tab_index = app_general.getint("main_tab_index", self.MAIN_TAB_INDEX_DEFAULT)
             self.ctrl_tab_index = app_general.getint("ctrl_tab_index", self.CTRL_TAB_INDEX_DEFAULT)
             self.settings_tab_index = app_general.getint("settings_tab_index", self.SETTINGS_TAB_INDEX_DEFAULT)
+            self.jog_probe_tab_index = app_general.getint("jog_probe_tab_index", self.JOG_PROBE_TAB_INDEX_DEFAULT)
             self.align_tab_visibility = app_general.getboolean("align_tab_visibility", self.SHOW_ALIGN_TAB_DEFAULT)
             self.settings_tab_visibility = app_general.getboolean("settings_tab_visibility",
                                                                   self.SHOW_SETTINGS_TAB_DEFAULT)
@@ -221,6 +224,7 @@ class AppSettingsHandler:
                                         "main_tab_index": self.MAIN_TAB_INDEX_DEFAULT,
                                         "ctrl_tab_index": self.CTRL_TAB_INDEX_DEFAULT,
                                         "settings_tab_index": self.SETTINGS_TAB_INDEX_DEFAULT,
+                                        "jog_probe_tab_index": self.JOG_PROBE_TAB_INDEX_DEFAULT,
                                         "align_tab_visibility": self.SHOW_ALIGN_TAB_DEFAULT,
                                         "settings_tab_visibility": self.SHOW_SETTINGS_TAB_DEFAULT,
                                         "console_visibility": self.console_visibility,
@@ -254,6 +258,7 @@ class AppSettingsHandler:
         app_general["main_tab_index"] = str(self.main_win.ui.main_tab_widget.currentIndex())
         app_general["ctrl_tab_index"] = str(self.main_win.ui.ctrl_tab_widget.currentIndex())
         app_general["settings_tab_index"] = str(self.main_win.ui.settings_sub_tab.currentIndex())
+        app_general["jog_probe_tab_index"] = str(self.main_win.ui.jog_probe_tab_widget.currentIndex())
         app_general["align_tab_visibility"] = str(self.main_win.ui.actionHide_Show_Align_Tab.isChecked())
         app_general["settings_tab_visibility"] = str(self.main_win.ui.actionSettings_Preferences.isChecked())
         app_general["console_visibility"] = str(self.main_win.ui.actionHide_Show_Console.isChecked())
@@ -298,6 +303,7 @@ class AppSettingsHandler:
                                         "main_tab_index": self.MAIN_TAB_INDEX_DEFAULT,
                                         "ctrl_tab_index": self.CTRL_TAB_INDEX_DEFAULT,
                                         "settings_tab_index": self.SETTINGS_TAB_INDEX_DEFAULT,
+                                        "jog_probe_tab_index": self.JOG_PROBE_TAB_INDEX_DEFAULT,
                                         "align_tab_visibility": self.SHOW_ALIGN_TAB_DEFAULT,
                                         "settings_tab_visibility": self.SHOW_SETTINGS_TAB_DEFAULT,
                                         "console_visibility": self.console_visibility,

--- a/src/TheAntFarm/the_ant_farm.ui
+++ b/src/TheAntFarm/the_ant_farm.ui
@@ -2772,7 +2772,7 @@
                 <item>
                  <layout class="QVBoxLayout" name="terminalVerticalLayout">
                   <item>
-                   <widget class="QTabWidget" name="tabWidget">
+                   <widget class="QTabWidget" name="jog_probe_tab_widget">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
                       <horstretch>0</horstretch>
@@ -2794,7 +2794,7 @@
                     <property name="tabBarAutoHide">
                      <bool>true</bool>
                     </property>
-                    <widget class="QWidget" name="tab">
+                    <widget class="QWidget" name="jog_tab">
                      <property name="enabled">
                       <bool>true</bool>
                      </property>
@@ -3760,7 +3760,7 @@
                       </item>
                      </layout>
                     </widget>
-                    <widget class="QWidget" name="tabWidgetPage2" native="true">
+                    <widget class="QWidget" name="probe_terminal_tab">
                      <attribute name="title">
                       <string>Probe/Terminal</string>
                      </attribute>

--- a/src/TheAntFarm/the_ant_farm.ui
+++ b/src/TheAntFarm/the_ant_farm.ui
@@ -2142,17 +2142,10 @@
                <number>0</number>
               </property>
               <item>
-               <layout class="QVBoxLayout" name="controlsVerticalLayout" stretch="0,0,0,0,0,0,0,0">
+               <layout class="QVBoxLayout" name="controlsVerticalLayout" stretch="0,0,0">
                 <property name="sizeConstraint">
                  <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
                 </property>
-                <item>
-                 <widget class="Line" name="line_4">
-                  <property name="orientation">
-                   <enum>Qt::Orientation::Horizontal</enum>
-                  </property>
-                 </widget>
-                </item>
                 <item>
                  <layout class="QGridLayout" name="droGridLayout">
                   <property name="leftMargin">
@@ -2770,715 +2763,6 @@
                  </layout>
                 </item>
                 <item>
-                 <widget class="Line" name="line_3">
-                  <property name="orientation">
-                   <enum>Qt::Orientation::Horizontal</enum>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <layout class="QGridLayout" name="probeABLGridLayout">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item row="0" column="0" alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
-                   <widget class="QPushButton" name="probe_pb">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>16777215</width>
-                      <height>23</height>
-                     </size>
-                    </property>
-                    <property name="text">
-                     <string>PROBE</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="2" alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
-                   <widget class="QPushButton" name="get_bbox_pb">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>16777215</width>
-                      <height>23</height>
-                     </size>
-                    </property>
-                    <property name="font">
-                     <font>
-                      <bold>true</bold>
-                     </font>
-                    </property>
-                    <property name="text">
-                     <string>GET BBOX</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="1">
-                   <layout class="QHBoxLayout" name="horizontalLayout_11">
-                    <item>
-                     <widget class="QPushButton" name="ABL_pb">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>0</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                      <property name="maximumSize">
-                       <size>
-                        <width>16777215</width>
-                        <height>23</height>
-                       </size>
-                      </property>
-                      <property name="font">
-                       <font>
-                        <bold>true</bold>
-                       </font>
-                      </property>
-                      <property name="text">
-                       <string>ABL</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QCheckBox" name="abl_active_chb">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>0</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                      <property name="maximumSize">
-                       <size>
-                        <width>16777215</width>
-                        <height>23</height>
-                       </size>
-                      </property>
-                      <property name="toolTip">
-                       <string>Apply ABL if checked</string>
-                      </property>
-                      <property name="text">
-                       <string/>
-                      </property>
-                      <property name="checked">
-                       <bool>true</bool>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                 </layout>
-                </item>
-                <item>
-                 <layout class="QGridLayout" name="stepsGridLayout">
-                  <property name="verticalSpacing">
-                   <number>0</number>
-                  </property>
-                  <item row="0" column="1">
-                   <widget class="QLabel" name="min_l">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>16777215</width>
-                      <height>23</height>
-                     </size>
-                    </property>
-                    <property name="font">
-                     <font>
-                      <bold>true</bold>
-                     </font>
-                    </property>
-                    <property name="text">
-                     <string>Min</string>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="2">
-                   <widget class="QLabel" name="max_l">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>16777215</width>
-                      <height>23</height>
-                     </size>
-                    </property>
-                    <property name="font">
-                     <font>
-                      <bold>true</bold>
-                     </font>
-                    </property>
-                    <property name="text">
-                     <string>Max</string>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="3">
-                   <widget class="QLabel" name="step_l">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>16777215</width>
-                      <height>23</height>
-                     </size>
-                    </property>
-                    <property name="font">
-                     <font>
-                      <bold>true</bold>
-                     </font>
-                    </property>
-                    <property name="text">
-                     <string>Step</string>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="4">
-                   <widget class="QLabel" name="n_step_l">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>16777215</width>
-                      <height>23</height>
-                     </size>
-                    </property>
-                    <property name="font">
-                     <font>
-                      <bold>true</bold>
-                     </font>
-                    </property>
-                    <property name="text">
-                     <string>N</string>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="0">
-                   <widget class="QLabel" name="x_l">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>16777215</width>
-                      <height>23</height>
-                     </size>
-                    </property>
-                    <property name="font">
-                     <font>
-                      <bold>true</bold>
-                     </font>
-                    </property>
-                    <property name="text">
-                     <string>X</string>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="1">
-                   <widget class="QDoubleSpinBox" name="x_min_dsb">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>16777215</width>
-                      <height>23</height>
-                     </size>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
-                    <property name="buttonSymbols">
-                     <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
-                    </property>
-                    <property name="minimum">
-                     <double>-1000.000000000000000</double>
-                    </property>
-                    <property name="maximum">
-                     <double>1000.000000000000000</double>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="2">
-                   <widget class="QDoubleSpinBox" name="x_max_dsb">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>16777215</width>
-                      <height>23</height>
-                     </size>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
-                    <property name="buttonSymbols">
-                     <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
-                    </property>
-                    <property name="minimum">
-                     <double>-1000.000000000000000</double>
-                    </property>
-                    <property name="maximum">
-                     <double>1000.000000000000000</double>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="3">
-                   <widget class="QDoubleSpinBox" name="x_step_dsb">
-                    <property name="enabled">
-                     <bool>false</bool>
-                    </property>
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>16777215</width>
-                      <height>23</height>
-                     </size>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
-                    <property name="readOnly">
-                     <bool>true</bool>
-                    </property>
-                    <property name="buttonSymbols">
-                     <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="4">
-                   <widget class="QSpinBox" name="x_num_step_sb">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>16777215</width>
-                      <height>23</height>
-                     </size>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
-                    <property name="minimum">
-                     <number>1</number>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="0">
-                   <widget class="QLabel" name="y_l">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>16777215</width>
-                      <height>23</height>
-                     </size>
-                    </property>
-                    <property name="font">
-                     <font>
-                      <bold>true</bold>
-                     </font>
-                    </property>
-                    <property name="text">
-                     <string>Y</string>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="1">
-                   <widget class="QDoubleSpinBox" name="y_min_dsb">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>16777215</width>
-                      <height>23</height>
-                     </size>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
-                    <property name="buttonSymbols">
-                     <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
-                    </property>
-                    <property name="minimum">
-                     <double>-1000.000000000000000</double>
-                    </property>
-                    <property name="maximum">
-                     <double>1000.000000000000000</double>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="2">
-                   <widget class="QDoubleSpinBox" name="y_max_dsb">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>16777215</width>
-                      <height>23</height>
-                     </size>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
-                    <property name="buttonSymbols">
-                     <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
-                    </property>
-                    <property name="minimum">
-                     <double>-1000.000000000000000</double>
-                    </property>
-                    <property name="maximum">
-                     <double>1000.000000000000000</double>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="3">
-                   <widget class="QDoubleSpinBox" name="y_step_dsb">
-                    <property name="enabled">
-                     <bool>false</bool>
-                    </property>
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>16777215</width>
-                      <height>23</height>
-                     </size>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
-                    <property name="readOnly">
-                     <bool>true</bool>
-                    </property>
-                    <property name="buttonSymbols">
-                     <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="4">
-                   <widget class="QSpinBox" name="y_num_step_sb">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>16777215</width>
-                      <height>23</height>
-                     </size>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
-                    <property name="minimum">
-                     <number>1</number>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="0">
-                   <widget class="QLabel" name="z_l">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>16777215</width>
-                      <height>23</height>
-                     </size>
-                    </property>
-                    <property name="font">
-                     <font>
-                      <bold>true</bold>
-                     </font>
-                    </property>
-                    <property name="text">
-                     <string>Z</string>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="1">
-                   <widget class="QDoubleSpinBox" name="z_min_dsb">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>16777215</width>
-                      <height>23</height>
-                     </size>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
-                    <property name="buttonSymbols">
-                     <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
-                    </property>
-                    <property name="minimum">
-                     <double>-1000.000000000000000</double>
-                    </property>
-                    <property name="maximum">
-                     <double>1000.000000000000000</double>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="2">
-                   <widget class="QDoubleSpinBox" name="z_max_dsb">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>16777215</width>
-                      <height>23</height>
-                     </size>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
-                    <property name="buttonSymbols">
-                     <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
-                    </property>
-                    <property name="minimum">
-                     <double>-1000.000000000000000</double>
-                    </property>
-                    <property name="maximum">
-                     <double>1000.000000000000000</double>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </item>
-                <item>
                  <widget class="Line" name="line">
                   <property name="orientation">
                    <enum>Qt::Orientation::Horizontal</enum>
@@ -3486,953 +2770,11 @@
                  </widget>
                 </item>
                 <item>
-                 <layout class="QGridLayout" name="jogGridlayout">
-                  <item row="2" column="0">
-                   <layout class="QGridLayout" name="zMoveGridLayout">
-                    <property name="sizeConstraint">
-                     <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
-                    </property>
-                    <item row="0" column="0">
-                     <widget class="QPushButton" name="z_plus_pb">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>0</width>
-                        <height>24</height>
-                       </size>
-                      </property>
-                      <property name="maximumSize">
-                       <size>
-                        <width>100</width>
-                        <height>16777215</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string>Z+</string>
-                      </property>
-                      <property name="icon">
-                       <iconset resource="app_resources.qrc">
-                        <normaloff>:/resources/resources/icons/white_north_arrow.svg</normaloff>:/resources/resources/icons/white_north_arrow.svg</iconset>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="1" column="0">
-                     <widget class="QPushButton" name="z_minus_pb">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>0</width>
-                        <height>24</height>
-                       </size>
-                      </property>
-                      <property name="maximumSize">
-                       <size>
-                        <width>100</width>
-                        <height>16777215</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string>Z-</string>
-                      </property>
-                      <property name="icon">
-                       <iconset resource="app_resources.qrc">
-                        <normaloff>:/resources/resources/icons/white_south_arrow.svg</normaloff>:/resources/resources/icons/white_south_arrow.svg</iconset>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                  <item row="0" column="0">
-                   <layout class="QGridLayout" name="xyMoveGridLayout" rowstretch="0,0,0">
-                    <property name="leftMargin">
-                     <number>0</number>
-                    </property>
-                    <property name="topMargin">
-                     <number>0</number>
-                    </property>
-                    <property name="rightMargin">
-                     <number>0</number>
-                    </property>
-                    <property name="bottomMargin">
-                     <number>0</number>
-                    </property>
-                    <item row="0" column="0">
-                     <widget class="QToolButton" name="x_minus_y_plus_pb">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>0</width>
-                        <height>22</height>
-                       </size>
-                      </property>
-                      <property name="maximumSize">
-                       <size>
-                        <width>50</width>
-                        <height>16777215</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string>X- Y+</string>
-                      </property>
-                      <property name="icon">
-                       <iconset resource="app_resources.qrc">
-                        <normaloff>:/resources/resources/icons/white_north_west_arrow.svg</normaloff>:/resources/resources/icons/white_north_west_arrow.svg</iconset>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="2" column="2">
-                     <widget class="QToolButton" name="x_plus_y_minus_pb">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>0</width>
-                        <height>22</height>
-                       </size>
-                      </property>
-                      <property name="maximumSize">
-                       <size>
-                        <width>50</width>
-                        <height>16777215</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string>X+ Y-</string>
-                      </property>
-                      <property name="icon">
-                       <iconset resource="app_resources.qrc">
-                        <normaloff>:/resources/resources/icons/white_south_east_arrow.svg</normaloff>:/resources/resources/icons/white_south_east_arrow.svg</iconset>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="1" column="0">
-                     <widget class="QToolButton" name="x_minus_pb">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>0</width>
-                        <height>22</height>
-                       </size>
-                      </property>
-                      <property name="maximumSize">
-                       <size>
-                        <width>50</width>
-                        <height>16777215</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string>X-</string>
-                      </property>
-                      <property name="icon">
-                       <iconset resource="app_resources.qrc">
-                        <normaloff>:/resources/resources/icons/white_west_arrow.svg</normaloff>:/resources/resources/icons/white_west_arrow.svg</iconset>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="2" column="0">
-                     <widget class="QToolButton" name="x_minus_y_minus_pb">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>0</width>
-                        <height>22</height>
-                       </size>
-                      </property>
-                      <property name="maximumSize">
-                       <size>
-                        <width>50</width>
-                        <height>16777215</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string>X- Y-</string>
-                      </property>
-                      <property name="icon">
-                       <iconset resource="app_resources.qrc">
-                        <normaloff>:/resources/resources/icons/white_south_west_arrow.svg</normaloff>:/resources/resources/icons/white_south_west_arrow.svg</iconset>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="0" column="1">
-                     <widget class="QToolButton" name="y_plus_pb">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>0</width>
-                        <height>22</height>
-                       </size>
-                      </property>
-                      <property name="maximumSize">
-                       <size>
-                        <width>50</width>
-                        <height>16777215</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string>Y+</string>
-                      </property>
-                      <property name="icon">
-                       <iconset resource="app_resources.qrc">
-                        <normaloff>:/resources/resources/icons/white_north_arrow.svg</normaloff>:/resources/resources/icons/white_north_arrow.svg</iconset>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="1" column="1">
-                     <widget class="QToolButton" name="center_tb">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>0</width>
-                        <height>22</height>
-                       </size>
-                      </property>
-                      <property name="maximumSize">
-                       <size>
-                        <width>50</width>
-                        <height>16777215</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string>Center</string>
-                      </property>
-                      <property name="icon">
-                       <iconset resource="app_resources.qrc">
-                        <normaloff>:/resources/resources/icons/white_circle.svg</normaloff>:/resources/resources/icons/white_circle.svg</iconset>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="2" column="1">
-                     <widget class="QToolButton" name="y_minus_pb">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>0</width>
-                        <height>22</height>
-                       </size>
-                      </property>
-                      <property name="maximumSize">
-                       <size>
-                        <width>50</width>
-                        <height>16777215</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string>Y-</string>
-                      </property>
-                      <property name="icon">
-                       <iconset resource="app_resources.qrc">
-                        <normaloff>:/resources/resources/icons/white_south_arrow.svg</normaloff>:/resources/resources/icons/white_south_arrow.svg</iconset>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="0" column="2">
-                     <widget class="QToolButton" name="x_plus_y_plus_pb">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>0</width>
-                        <height>22</height>
-                       </size>
-                      </property>
-                      <property name="maximumSize">
-                       <size>
-                        <width>50</width>
-                        <height>16777215</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string>X+ Y+</string>
-                      </property>
-                      <property name="icon">
-                       <iconset resource="app_resources.qrc">
-                        <normaloff>:/resources/resources/icons/white_north_east_arrow.svg</normaloff>:/resources/resources/icons/white_north_east_arrow.svg</iconset>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="1" column="2">
-                     <widget class="QToolButton" name="x_plus_pb">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>0</width>
-                        <height>22</height>
-                       </size>
-                      </property>
-                      <property name="maximumSize">
-                       <size>
-                        <width>50</width>
-                        <height>16777215</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string>X+</string>
-                      </property>
-                      <property name="icon">
-                       <iconset resource="app_resources.qrc">
-                        <normaloff>:/resources/resources/icons/white_east_arrow.svg</normaloff>:/resources/resources/icons/white_east_arrow.svg</iconset>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                  <item row="2" column="1">
-                   <layout class="QVBoxLayout" name="zStepAdjustmentVerticalLayout">
-                    <item>
-                     <layout class="QHBoxLayout" name="horizontalLayout_14">
-                      <property name="sizeConstraint">
-                       <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
-                      </property>
-                      <item alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
-                       <widget class="QLabel" name="z_jog_l_2">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="minimumSize">
-                         <size>
-                          <width>0</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                        <property name="maximumSize">
-                         <size>
-                          <width>16777215</width>
-                          <height>23</height>
-                         </size>
-                        </property>
-                        <property name="font">
-                         <font>
-                          <bold>true</bold>
-                         </font>
-                        </property>
-                        <property name="text">
-                         <string>Z step [mm]</string>
-                        </property>
-                        <property name="alignment">
-                         <set>Qt::AlignmentFlag::AlignCenter</set>
-                        </property>
-                       </widget>
-                      </item>
-                      <item alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
-                       <widget class="QComboBox" name="z_step_cb">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="minimumSize">
-                         <size>
-                          <width>75</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                        <property name="maximumSize">
-                         <size>
-                          <width>75</width>
-                          <height>16777215</height>
-                         </size>
-                        </property>
-                        <property name="font">
-                         <font>
-                          <bold>true</bold>
-                         </font>
-                        </property>
-                        <property name="currentIndex">
-                         <number>3</number>
-                        </property>
-                        <item>
-                         <property name="text">
-                          <string>100.0</string>
-                         </property>
-                        </item>
-                        <item>
-                         <property name="text">
-                          <string>10.0</string>
-                         </property>
-                        </item>
-                        <item>
-                         <property name="text">
-                          <string>5.0</string>
-                         </property>
-                        </item>
-                        <item>
-                         <property name="text">
-                          <string>1.0</string>
-                         </property>
-                        </item>
-                        <item>
-                         <property name="text">
-                          <string>0.5</string>
-                         </property>
-                        </item>
-                        <item>
-                         <property name="text">
-                          <string>0.1</string>
-                         </property>
-                        </item>
-                        <item>
-                         <property name="text">
-                          <string>0.05</string>
-                         </property>
-                        </item>
-                        <item>
-                         <property name="text">
-                          <string>0.01</string>
-                         </property>
-                        </item>
-                       </widget>
-                      </item>
-                     </layout>
-                    </item>
-                    <item>
-                     <layout class="QGridLayout" name="gridLayout_18">
-                      <item row="1" column="1">
-                       <widget class="QDoubleSpinBox" name="z_step_val_dsb">
-                        <property name="minimumSize">
-                         <size>
-                          <width>70</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                        <property name="maximumSize">
-                         <size>
-                          <width>70</width>
-                          <height>16777215</height>
-                         </size>
-                        </property>
-                        <property name="font">
-                         <font>
-                          <bold>true</bold>
-                         </font>
-                        </property>
-                        <property name="alignment">
-                         <set>Qt::AlignmentFlag::AlignCenter</set>
-                        </property>
-                        <property name="buttonSymbols">
-                         <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
-                        </property>
-                        <property name="minimum">
-                         <double>0.010000000000000</double>
-                        </property>
-                        <property name="maximum">
-                         <double>1000.000000000000000</double>
-                        </property>
-                        <property name="singleStep">
-                         <double>0.100000000000000</double>
-                        </property>
-                        <property name="value">
-                         <double>0.100000000000000</double>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="1" column="2">
-                       <widget class="QPushButton" name="z_mul_10_pb">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="minimumSize">
-                         <size>
-                          <width>0</width>
-                          <height>23</height>
-                         </size>
-                        </property>
-                        <property name="maximumSize">
-                         <size>
-                          <width>50</width>
-                          <height>16777215</height>
-                         </size>
-                        </property>
-                        <property name="font">
-                         <font>
-                          <pointsize>8</pointsize>
-                          <bold>true</bold>
-                         </font>
-                        </property>
-                        <property name="text">
-                         <string>x10</string>
-                        </property>
-                        <property name="autoRepeat">
-                         <bool>false</bool>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="1" column="0">
-                       <widget class="QPushButton" name="z_div_10_pb">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="minimumSize">
-                         <size>
-                          <width>0</width>
-                          <height>23</height>
-                         </size>
-                        </property>
-                        <property name="maximumSize">
-                         <size>
-                          <width>50</width>
-                          <height>16777215</height>
-                         </size>
-                        </property>
-                        <property name="font">
-                         <font>
-                          <bold>true</bold>
-                         </font>
-                        </property>
-                        <property name="text">
-                         <string>÷10</string>
-                        </property>
-                        <property name="autoRepeat">
-                         <bool>false</bool>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="2" column="1">
-                       <widget class="QPushButton" name="z_minus_1_pb">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="minimumSize">
-                         <size>
-                          <width>70</width>
-                          <height>23</height>
-                         </size>
-                        </property>
-                        <property name="maximumSize">
-                         <size>
-                          <width>70</width>
-                          <height>16777215</height>
-                         </size>
-                        </property>
-                        <property name="font">
-                         <font>
-                          <bold>true</bold>
-                         </font>
-                        </property>
-                        <property name="text">
-                         <string>-1.0</string>
-                        </property>
-                        <property name="autoRepeat">
-                         <bool>true</bool>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="0" column="1">
-                       <widget class="QPushButton" name="z_plus_1_pb">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="minimumSize">
-                         <size>
-                          <width>70</width>
-                          <height>23</height>
-                         </size>
-                        </property>
-                        <property name="maximumSize">
-                         <size>
-                          <width>70</width>
-                          <height>16777215</height>
-                         </size>
-                        </property>
-                        <property name="font">
-                         <font>
-                          <bold>true</bold>
-                         </font>
-                        </property>
-                        <property name="text">
-                         <string>+1.0</string>
-                        </property>
-                        <property name="autoRepeat">
-                         <bool>true</bool>
-                        </property>
-                       </widget>
-                      </item>
-                     </layout>
-                    </item>
-                   </layout>
-                  </item>
-                  <item row="0" column="1">
-                   <layout class="QVBoxLayout" name="xyStepAdjustmentVerticalLayout">
-                    <item>
-                     <layout class="QHBoxLayout" name="horizontalLayout_12">
-                      <property name="sizeConstraint">
-                       <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
-                      </property>
-                      <item alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
-                       <widget class="QLabel" name="xy_jog_l">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="minimumSize">
-                         <size>
-                          <width>0</width>
-                          <height>0</height>
-                         </size>
-                        </property>
-                        <property name="maximumSize">
-                         <size>
-                          <width>16777215</width>
-                          <height>23</height>
-                         </size>
-                        </property>
-                        <property name="text">
-                         <string>XY step [mm]</string>
-                        </property>
-                        <property name="alignment">
-                         <set>Qt::AlignmentFlag::AlignCenter</set>
-                        </property>
-                       </widget>
-                      </item>
-                      <item alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
-                       <widget class="QComboBox" name="xy_step_cb">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="minimumSize">
-                         <size>
-                          <width>75</width>
-                          <height>0</height>
-                         </size>
-                        </property>
-                        <property name="maximumSize">
-                         <size>
-                          <width>75</width>
-                          <height>23</height>
-                         </size>
-                        </property>
-                        <property name="currentIndex">
-                         <number>3</number>
-                        </property>
-                        <item>
-                         <property name="text">
-                          <string>100.0</string>
-                         </property>
-                        </item>
-                        <item>
-                         <property name="text">
-                          <string>10.0</string>
-                         </property>
-                        </item>
-                        <item>
-                         <property name="text">
-                          <string>5.0</string>
-                         </property>
-                        </item>
-                        <item>
-                         <property name="text">
-                          <string>1.0</string>
-                         </property>
-                        </item>
-                        <item>
-                         <property name="text">
-                          <string>0.5</string>
-                         </property>
-                        </item>
-                        <item>
-                         <property name="text">
-                          <string>0.1</string>
-                         </property>
-                        </item>
-                        <item>
-                         <property name="text">
-                          <string>0.05</string>
-                         </property>
-                        </item>
-                        <item>
-                         <property name="text">
-                          <string>0.01</string>
-                         </property>
-                        </item>
-                       </widget>
-                      </item>
-                     </layout>
-                    </item>
-                    <item>
-                     <layout class="QGridLayout" name="gridLayout_16">
-                      <item row="0" column="1">
-                       <widget class="QPushButton" name="xy_plus_1_pb">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="minimumSize">
-                         <size>
-                          <width>70</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                        <property name="maximumSize">
-                         <size>
-                          <width>70</width>
-                          <height>23</height>
-                         </size>
-                        </property>
-                        <property name="font">
-                         <font>
-                          <bold>true</bold>
-                         </font>
-                        </property>
-                        <property name="text">
-                         <string>+1.0</string>
-                        </property>
-                        <property name="autoRepeat">
-                         <bool>true</bool>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="1" column="0">
-                       <widget class="QPushButton" name="xy_div_10_pb">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="minimumSize">
-                         <size>
-                          <width>50</width>
-                          <height>23</height>
-                         </size>
-                        </property>
-                        <property name="maximumSize">
-                         <size>
-                          <width>50</width>
-                          <height>23</height>
-                         </size>
-                        </property>
-                        <property name="font">
-                         <font>
-                          <bold>true</bold>
-                         </font>
-                        </property>
-                        <property name="text">
-                         <string>÷10</string>
-                        </property>
-                        <property name="autoRepeat">
-                         <bool>false</bool>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="1" column="1">
-                       <widget class="QDoubleSpinBox" name="xy_step_val_dsb">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="minimumSize">
-                         <size>
-                          <width>70</width>
-                          <height>23</height>
-                         </size>
-                        </property>
-                        <property name="maximumSize">
-                         <size>
-                          <width>70</width>
-                          <height>23</height>
-                         </size>
-                        </property>
-                        <property name="font">
-                         <font>
-                          <bold>true</bold>
-                         </font>
-                        </property>
-                        <property name="alignment">
-                         <set>Qt::AlignmentFlag::AlignCenter</set>
-                        </property>
-                        <property name="buttonSymbols">
-                         <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
-                        </property>
-                        <property name="minimum">
-                         <double>0.010000000000000</double>
-                        </property>
-                        <property name="maximum">
-                         <double>1000.000000000000000</double>
-                        </property>
-                        <property name="singleStep">
-                         <double>0.100000000000000</double>
-                        </property>
-                        <property name="value">
-                         <double>0.100000000000000</double>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="1" column="2">
-                       <widget class="QPushButton" name="xy_mul_10_pb">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="minimumSize">
-                         <size>
-                          <width>50</width>
-                          <height>23</height>
-                         </size>
-                        </property>
-                        <property name="maximumSize">
-                         <size>
-                          <width>50</width>
-                          <height>23</height>
-                         </size>
-                        </property>
-                        <property name="font">
-                         <font>
-                          <pointsize>8</pointsize>
-                          <bold>true</bold>
-                         </font>
-                        </property>
-                        <property name="text">
-                         <string>x10</string>
-                        </property>
-                        <property name="autoRepeat">
-                         <bool>false</bool>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="2" column="1">
-                       <widget class="QPushButton" name="xy_minus_1_pb">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="minimumSize">
-                         <size>
-                          <width>70</width>
-                          <height>23</height>
-                         </size>
-                        </property>
-                        <property name="maximumSize">
-                         <size>
-                          <width>70</width>
-                          <height>23</height>
-                         </size>
-                        </property>
-                        <property name="font">
-                         <font>
-                          <bold>true</bold>
-                         </font>
-                        </property>
-                        <property name="text">
-                         <string>-1.0</string>
-                        </property>
-                        <property name="autoRepeat">
-                         <bool>true</bool>
-                        </property>
-                       </widget>
-                      </item>
-                     </layout>
-                    </item>
-                   </layout>
-                  </item>
-                  <item row="1" column="1">
-                   <widget class="Line" name="line_2">
-                    <property name="lineWidth">
-                     <number>1</number>
-                    </property>
-                    <property name="orientation">
-                     <enum>Qt::Orientation::Horizontal</enum>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="0">
-                   <widget class="Line" name="line_5">
-                    <property name="orientation">
-                     <enum>Qt::Orientation::Horizontal</enum>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </item>
-                <item>
                  <layout class="QVBoxLayout" name="terminalVerticalLayout">
                   <item>
-                   <widget class="QTextEdit" name="serial_te">
-                    <property name="enabled">
-                     <bool>true</bool>
-                    </property>
+                   <widget class="QTabWidget" name="tabWidget">
                     <property name="sizePolicy">
-                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
                       <horstretch>0</horstretch>
                       <verstretch>0</verstretch>
                      </sizepolicy>
@@ -4440,201 +2782,1918 @@
                     <property name="minimumSize">
                      <size>
                       <width>0</width>
-                      <height>40</height>
+                      <height>0</height>
                      </size>
                     </property>
-                    <property name="frameShadow">
-                     <enum>QFrame::Shadow::Sunken</enum>
+                    <property name="tabPosition">
+                     <enum>QTabWidget::TabPosition::South</enum>
                     </property>
-                    <property name="verticalScrollBarPolicy">
-                     <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOn</enum>
+                    <property name="currentIndex">
+                     <number>1</number>
                     </property>
-                    <property name="textInteractionFlags">
-                     <set>Qt::TextInteractionFlag::TextSelectableByKeyboard|Qt::TextInteractionFlag::TextSelectableByMouse</set>
+                    <property name="tabBarAutoHide">
+                     <bool>true</bool>
                     </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_2">
-                    <item>
-                     <widget class="ComboBoxFilterEnter" name="send_cb">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="autoFillBackground">
-                       <bool>true</bool>
-                      </property>
-                      <property name="editable">
-                       <bool>true</bool>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QPushButton" name="send_pb">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="font">
-                       <font>
-                        <bold>true</bold>
-                       </font>
-                      </property>
-                      <property name="text">
-                       <string>Send</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                  <item>
-                   <layout class="QVBoxLayout" name="connectVerticalLayout">
-                    <property name="spacing">
-                     <number>6</number>
-                    </property>
-                    <property name="leftMargin">
-                     <number>5</number>
-                    </property>
-                    <property name="topMargin">
-                     <number>0</number>
-                    </property>
-                    <property name="rightMargin">
-                     <number>5</number>
-                    </property>
-                    <property name="bottomMargin">
-                     <number>0</number>
-                    </property>
-                    <item>
-                     <layout class="QHBoxLayout" name="horizontalLayout">
-                      <property name="spacing">
-                       <number>6</number>
-                      </property>
+                    <widget class="QWidget" name="tab">
+                     <property name="enabled">
+                      <bool>true</bool>
+                     </property>
+                     <attribute name="title">
+                      <string>Jog</string>
+                     </attribute>
+                     <layout class="QHBoxLayout" name="horizontalLayout_19">
                       <item>
-                       <widget class="QComboBox" name="serial_ports_cb">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="toolTip">
-                         <string>Available serial ports.</string>
-                        </property>
-                        <property name="statusTip">
-                         <string>Available serial ports.</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QComboBox" name="serial_baud_cb">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="toolTip">
-                         <string>Serial port baudrate [bps]</string>
-                        </property>
-                        <property name="statusTip">
-                         <string>Serial port baudrate [bps]</string>
-                        </property>
-                        <property name="currentText">
-                         <string/>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QPushButton" name="refresh_pb">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="font">
-                         <font>
-                          <bold>true</bold>
-                         </font>
-                        </property>
-                        <property name="statusTip">
-                         <string>Refresh serial port list.</string>
-                        </property>
-                        <property name="text">
-                         <string>Serial Ports Refresh</string>
-                        </property>
-                        <property name="checkable">
-                         <bool>false</bool>
-                        </property>
-                       </widget>
+                       <layout class="QVBoxLayout" name="verticalLayout_18">
+                        <item>
+                         <layout class="QGridLayout" name="jogGridlayout">
+                          <item row="2" column="0">
+                           <layout class="QGridLayout" name="zMoveGridLayout">
+                            <property name="sizeConstraint">
+                             <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+                            </property>
+                            <item row="0" column="0">
+                             <widget class="QPushButton" name="z_plus_pb">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <property name="minimumSize">
+                               <size>
+                                <width>0</width>
+                                <height>24</height>
+                               </size>
+                              </property>
+                              <property name="maximumSize">
+                               <size>
+                                <width>100</width>
+                                <height>16777215</height>
+                               </size>
+                              </property>
+                              <property name="text">
+                               <string>Z+</string>
+                              </property>
+                              <property name="icon">
+                               <iconset resource="app_resources.qrc">
+                                <normaloff>:/resources/resources/icons/white_north_arrow.svg</normaloff>:/resources/resources/icons/white_north_arrow.svg</iconset>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="1" column="0">
+                             <widget class="QPushButton" name="z_minus_pb">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <property name="minimumSize">
+                               <size>
+                                <width>0</width>
+                                <height>24</height>
+                               </size>
+                              </property>
+                              <property name="maximumSize">
+                               <size>
+                                <width>100</width>
+                                <height>16777215</height>
+                               </size>
+                              </property>
+                              <property name="text">
+                               <string>Z-</string>
+                              </property>
+                              <property name="icon">
+                               <iconset resource="app_resources.qrc">
+                                <normaloff>:/resources/resources/icons/white_south_arrow.svg</normaloff>:/resources/resources/icons/white_south_arrow.svg</iconset>
+                              </property>
+                             </widget>
+                            </item>
+                           </layout>
+                          </item>
+                          <item row="0" column="0">
+                           <layout class="QGridLayout" name="xyMoveGridLayout" rowstretch="0,0,0">
+                            <property name="leftMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="topMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="rightMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="bottomMargin">
+                             <number>0</number>
+                            </property>
+                            <item row="0" column="0">
+                             <widget class="QToolButton" name="x_minus_y_plus_pb">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <property name="minimumSize">
+                               <size>
+                                <width>0</width>
+                                <height>22</height>
+                               </size>
+                              </property>
+                              <property name="maximumSize">
+                               <size>
+                                <width>50</width>
+                                <height>16777215</height>
+                               </size>
+                              </property>
+                              <property name="text">
+                               <string>X- Y+</string>
+                              </property>
+                              <property name="icon">
+                               <iconset resource="app_resources.qrc">
+                                <normaloff>:/resources/resources/icons/white_north_west_arrow.svg</normaloff>:/resources/resources/icons/white_north_west_arrow.svg</iconset>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="2" column="2">
+                             <widget class="QToolButton" name="x_plus_y_minus_pb">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <property name="minimumSize">
+                               <size>
+                                <width>0</width>
+                                <height>22</height>
+                               </size>
+                              </property>
+                              <property name="maximumSize">
+                               <size>
+                                <width>50</width>
+                                <height>16777215</height>
+                               </size>
+                              </property>
+                              <property name="text">
+                               <string>X+ Y-</string>
+                              </property>
+                              <property name="icon">
+                               <iconset resource="app_resources.qrc">
+                                <normaloff>:/resources/resources/icons/white_south_east_arrow.svg</normaloff>:/resources/resources/icons/white_south_east_arrow.svg</iconset>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="1" column="0">
+                             <widget class="QToolButton" name="x_minus_pb">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <property name="minimumSize">
+                               <size>
+                                <width>0</width>
+                                <height>22</height>
+                               </size>
+                              </property>
+                              <property name="maximumSize">
+                               <size>
+                                <width>50</width>
+                                <height>16777215</height>
+                               </size>
+                              </property>
+                              <property name="text">
+                               <string>X-</string>
+                              </property>
+                              <property name="icon">
+                               <iconset resource="app_resources.qrc">
+                                <normaloff>:/resources/resources/icons/white_west_arrow.svg</normaloff>:/resources/resources/icons/white_west_arrow.svg</iconset>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="2" column="0">
+                             <widget class="QToolButton" name="x_minus_y_minus_pb">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <property name="minimumSize">
+                               <size>
+                                <width>0</width>
+                                <height>22</height>
+                               </size>
+                              </property>
+                              <property name="maximumSize">
+                               <size>
+                                <width>50</width>
+                                <height>16777215</height>
+                               </size>
+                              </property>
+                              <property name="text">
+                               <string>X- Y-</string>
+                              </property>
+                              <property name="icon">
+                               <iconset resource="app_resources.qrc">
+                                <normaloff>:/resources/resources/icons/white_south_west_arrow.svg</normaloff>:/resources/resources/icons/white_south_west_arrow.svg</iconset>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="0" column="1">
+                             <widget class="QToolButton" name="y_plus_pb">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <property name="minimumSize">
+                               <size>
+                                <width>0</width>
+                                <height>22</height>
+                               </size>
+                              </property>
+                              <property name="maximumSize">
+                               <size>
+                                <width>50</width>
+                                <height>16777215</height>
+                               </size>
+                              </property>
+                              <property name="text">
+                               <string>Y+</string>
+                              </property>
+                              <property name="icon">
+                               <iconset resource="app_resources.qrc">
+                                <normaloff>:/resources/resources/icons/white_north_arrow.svg</normaloff>:/resources/resources/icons/white_north_arrow.svg</iconset>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="1" column="1">
+                             <widget class="QToolButton" name="center_tb">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <property name="minimumSize">
+                               <size>
+                                <width>0</width>
+                                <height>22</height>
+                               </size>
+                              </property>
+                              <property name="maximumSize">
+                               <size>
+                                <width>50</width>
+                                <height>16777215</height>
+                               </size>
+                              </property>
+                              <property name="text">
+                               <string>Center</string>
+                              </property>
+                              <property name="icon">
+                               <iconset resource="app_resources.qrc">
+                                <normaloff>:/resources/resources/icons/white_circle.svg</normaloff>:/resources/resources/icons/white_circle.svg</iconset>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="2" column="1">
+                             <widget class="QToolButton" name="y_minus_pb">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <property name="minimumSize">
+                               <size>
+                                <width>0</width>
+                                <height>22</height>
+                               </size>
+                              </property>
+                              <property name="maximumSize">
+                               <size>
+                                <width>50</width>
+                                <height>16777215</height>
+                               </size>
+                              </property>
+                              <property name="text">
+                               <string>Y-</string>
+                              </property>
+                              <property name="icon">
+                               <iconset resource="app_resources.qrc">
+                                <normaloff>:/resources/resources/icons/white_south_arrow.svg</normaloff>:/resources/resources/icons/white_south_arrow.svg</iconset>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="0" column="2">
+                             <widget class="QToolButton" name="x_plus_y_plus_pb">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <property name="minimumSize">
+                               <size>
+                                <width>0</width>
+                                <height>22</height>
+                               </size>
+                              </property>
+                              <property name="maximumSize">
+                               <size>
+                                <width>50</width>
+                                <height>16777215</height>
+                               </size>
+                              </property>
+                              <property name="text">
+                               <string>X+ Y+</string>
+                              </property>
+                              <property name="icon">
+                               <iconset resource="app_resources.qrc">
+                                <normaloff>:/resources/resources/icons/white_north_east_arrow.svg</normaloff>:/resources/resources/icons/white_north_east_arrow.svg</iconset>
+                              </property>
+                             </widget>
+                            </item>
+                            <item row="1" column="2">
+                             <widget class="QToolButton" name="x_plus_pb">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <property name="minimumSize">
+                               <size>
+                                <width>0</width>
+                                <height>22</height>
+                               </size>
+                              </property>
+                              <property name="maximumSize">
+                               <size>
+                                <width>50</width>
+                                <height>16777215</height>
+                               </size>
+                              </property>
+                              <property name="text">
+                               <string>X+</string>
+                              </property>
+                              <property name="icon">
+                               <iconset resource="app_resources.qrc">
+                                <normaloff>:/resources/resources/icons/white_east_arrow.svg</normaloff>:/resources/resources/icons/white_east_arrow.svg</iconset>
+                              </property>
+                             </widget>
+                            </item>
+                           </layout>
+                          </item>
+                          <item row="2" column="1">
+                           <layout class="QVBoxLayout" name="zStepAdjustmentVerticalLayout">
+                            <item>
+                             <layout class="QHBoxLayout" name="horizontalLayout_14">
+                              <property name="sizeConstraint">
+                               <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+                              </property>
+                              <item alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                               <widget class="QLabel" name="z_jog_l_2">
+                                <property name="sizePolicy">
+                                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                 </sizepolicy>
+                                </property>
+                                <property name="minimumSize">
+                                 <size>
+                                  <width>0</width>
+                                  <height>20</height>
+                                 </size>
+                                </property>
+                                <property name="maximumSize">
+                                 <size>
+                                  <width>16777215</width>
+                                  <height>23</height>
+                                 </size>
+                                </property>
+                                <property name="font">
+                                 <font>
+                                  <bold>true</bold>
+                                 </font>
+                                </property>
+                                <property name="text">
+                                 <string>Z step [mm]</string>
+                                </property>
+                                <property name="alignment">
+                                 <set>Qt::AlignmentFlag::AlignCenter</set>
+                                </property>
+                               </widget>
+                              </item>
+                              <item alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                               <widget class="QComboBox" name="z_step_cb">
+                                <property name="sizePolicy">
+                                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                 </sizepolicy>
+                                </property>
+                                <property name="minimumSize">
+                                 <size>
+                                  <width>75</width>
+                                  <height>20</height>
+                                 </size>
+                                </property>
+                                <property name="maximumSize">
+                                 <size>
+                                  <width>75</width>
+                                  <height>16777215</height>
+                                 </size>
+                                </property>
+                                <property name="font">
+                                 <font>
+                                  <bold>true</bold>
+                                 </font>
+                                </property>
+                                <property name="currentIndex">
+                                 <number>3</number>
+                                </property>
+                                <item>
+                                 <property name="text">
+                                  <string>100.0</string>
+                                 </property>
+                                </item>
+                                <item>
+                                 <property name="text">
+                                  <string>10.0</string>
+                                 </property>
+                                </item>
+                                <item>
+                                 <property name="text">
+                                  <string>5.0</string>
+                                 </property>
+                                </item>
+                                <item>
+                                 <property name="text">
+                                  <string>1.0</string>
+                                 </property>
+                                </item>
+                                <item>
+                                 <property name="text">
+                                  <string>0.5</string>
+                                 </property>
+                                </item>
+                                <item>
+                                 <property name="text">
+                                  <string>0.1</string>
+                                 </property>
+                                </item>
+                                <item>
+                                 <property name="text">
+                                  <string>0.05</string>
+                                 </property>
+                                </item>
+                                <item>
+                                 <property name="text">
+                                  <string>0.01</string>
+                                 </property>
+                                </item>
+                               </widget>
+                              </item>
+                             </layout>
+                            </item>
+                            <item>
+                             <layout class="QGridLayout" name="gridLayout_18">
+                              <item row="1" column="1">
+                               <widget class="QDoubleSpinBox" name="z_step_val_dsb">
+                                <property name="minimumSize">
+                                 <size>
+                                  <width>70</width>
+                                  <height>20</height>
+                                 </size>
+                                </property>
+                                <property name="maximumSize">
+                                 <size>
+                                  <width>70</width>
+                                  <height>16777215</height>
+                                 </size>
+                                </property>
+                                <property name="font">
+                                 <font>
+                                  <bold>true</bold>
+                                 </font>
+                                </property>
+                                <property name="alignment">
+                                 <set>Qt::AlignmentFlag::AlignCenter</set>
+                                </property>
+                                <property name="buttonSymbols">
+                                 <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                                </property>
+                                <property name="minimum">
+                                 <double>0.010000000000000</double>
+                                </property>
+                                <property name="maximum">
+                                 <double>1000.000000000000000</double>
+                                </property>
+                                <property name="singleStep">
+                                 <double>0.100000000000000</double>
+                                </property>
+                                <property name="value">
+                                 <double>0.100000000000000</double>
+                                </property>
+                               </widget>
+                              </item>
+                              <item row="1" column="2">
+                               <widget class="QPushButton" name="z_mul_10_pb">
+                                <property name="sizePolicy">
+                                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                 </sizepolicy>
+                                </property>
+                                <property name="minimumSize">
+                                 <size>
+                                  <width>0</width>
+                                  <height>23</height>
+                                 </size>
+                                </property>
+                                <property name="maximumSize">
+                                 <size>
+                                  <width>50</width>
+                                  <height>16777215</height>
+                                 </size>
+                                </property>
+                                <property name="font">
+                                 <font>
+                                  <pointsize>8</pointsize>
+                                  <bold>true</bold>
+                                 </font>
+                                </property>
+                                <property name="text">
+                                 <string>x10</string>
+                                </property>
+                                <property name="autoRepeat">
+                                 <bool>false</bool>
+                                </property>
+                               </widget>
+                              </item>
+                              <item row="1" column="0">
+                               <widget class="QPushButton" name="z_div_10_pb">
+                                <property name="sizePolicy">
+                                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                 </sizepolicy>
+                                </property>
+                                <property name="minimumSize">
+                                 <size>
+                                  <width>0</width>
+                                  <height>23</height>
+                                 </size>
+                                </property>
+                                <property name="maximumSize">
+                                 <size>
+                                  <width>50</width>
+                                  <height>16777215</height>
+                                 </size>
+                                </property>
+                                <property name="font">
+                                 <font>
+                                  <bold>true</bold>
+                                 </font>
+                                </property>
+                                <property name="text">
+                                 <string>÷10</string>
+                                </property>
+                                <property name="autoRepeat">
+                                 <bool>false</bool>
+                                </property>
+                               </widget>
+                              </item>
+                              <item row="2" column="1">
+                               <widget class="QPushButton" name="z_minus_1_pb">
+                                <property name="sizePolicy">
+                                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                 </sizepolicy>
+                                </property>
+                                <property name="minimumSize">
+                                 <size>
+                                  <width>70</width>
+                                  <height>23</height>
+                                 </size>
+                                </property>
+                                <property name="maximumSize">
+                                 <size>
+                                  <width>70</width>
+                                  <height>16777215</height>
+                                 </size>
+                                </property>
+                                <property name="font">
+                                 <font>
+                                  <bold>true</bold>
+                                 </font>
+                                </property>
+                                <property name="text">
+                                 <string>-1.0</string>
+                                </property>
+                                <property name="autoRepeat">
+                                 <bool>true</bool>
+                                </property>
+                               </widget>
+                              </item>
+                              <item row="0" column="1">
+                               <widget class="QPushButton" name="z_plus_1_pb">
+                                <property name="sizePolicy">
+                                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                 </sizepolicy>
+                                </property>
+                                <property name="minimumSize">
+                                 <size>
+                                  <width>70</width>
+                                  <height>23</height>
+                                 </size>
+                                </property>
+                                <property name="maximumSize">
+                                 <size>
+                                  <width>70</width>
+                                  <height>16777215</height>
+                                 </size>
+                                </property>
+                                <property name="font">
+                                 <font>
+                                  <bold>true</bold>
+                                 </font>
+                                </property>
+                                <property name="text">
+                                 <string>+1.0</string>
+                                </property>
+                                <property name="autoRepeat">
+                                 <bool>true</bool>
+                                </property>
+                               </widget>
+                              </item>
+                             </layout>
+                            </item>
+                           </layout>
+                          </item>
+                          <item row="0" column="1">
+                           <layout class="QVBoxLayout" name="xyStepAdjustmentVerticalLayout">
+                            <item>
+                             <layout class="QHBoxLayout" name="horizontalLayout_12">
+                              <property name="sizeConstraint">
+                               <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+                              </property>
+                              <item alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                               <widget class="QLabel" name="xy_jog_l">
+                                <property name="sizePolicy">
+                                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                 </sizepolicy>
+                                </property>
+                                <property name="minimumSize">
+                                 <size>
+                                  <width>0</width>
+                                  <height>0</height>
+                                 </size>
+                                </property>
+                                <property name="maximumSize">
+                                 <size>
+                                  <width>16777215</width>
+                                  <height>23</height>
+                                 </size>
+                                </property>
+                                <property name="text">
+                                 <string>XY step [mm]</string>
+                                </property>
+                                <property name="alignment">
+                                 <set>Qt::AlignmentFlag::AlignCenter</set>
+                                </property>
+                               </widget>
+                              </item>
+                              <item alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                               <widget class="QComboBox" name="xy_step_cb">
+                                <property name="sizePolicy">
+                                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                 </sizepolicy>
+                                </property>
+                                <property name="minimumSize">
+                                 <size>
+                                  <width>75</width>
+                                  <height>0</height>
+                                 </size>
+                                </property>
+                                <property name="maximumSize">
+                                 <size>
+                                  <width>75</width>
+                                  <height>23</height>
+                                 </size>
+                                </property>
+                                <property name="currentIndex">
+                                 <number>3</number>
+                                </property>
+                                <item>
+                                 <property name="text">
+                                  <string>100.0</string>
+                                 </property>
+                                </item>
+                                <item>
+                                 <property name="text">
+                                  <string>10.0</string>
+                                 </property>
+                                </item>
+                                <item>
+                                 <property name="text">
+                                  <string>5.0</string>
+                                 </property>
+                                </item>
+                                <item>
+                                 <property name="text">
+                                  <string>1.0</string>
+                                 </property>
+                                </item>
+                                <item>
+                                 <property name="text">
+                                  <string>0.5</string>
+                                 </property>
+                                </item>
+                                <item>
+                                 <property name="text">
+                                  <string>0.1</string>
+                                 </property>
+                                </item>
+                                <item>
+                                 <property name="text">
+                                  <string>0.05</string>
+                                 </property>
+                                </item>
+                                <item>
+                                 <property name="text">
+                                  <string>0.01</string>
+                                 </property>
+                                </item>
+                               </widget>
+                              </item>
+                             </layout>
+                            </item>
+                            <item>
+                             <layout class="QGridLayout" name="gridLayout_16">
+                              <item row="0" column="1">
+                               <widget class="QPushButton" name="xy_plus_1_pb">
+                                <property name="sizePolicy">
+                                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                 </sizepolicy>
+                                </property>
+                                <property name="minimumSize">
+                                 <size>
+                                  <width>70</width>
+                                  <height>20</height>
+                                 </size>
+                                </property>
+                                <property name="maximumSize">
+                                 <size>
+                                  <width>70</width>
+                                  <height>23</height>
+                                 </size>
+                                </property>
+                                <property name="font">
+                                 <font>
+                                  <bold>true</bold>
+                                 </font>
+                                </property>
+                                <property name="text">
+                                 <string>+1.0</string>
+                                </property>
+                                <property name="autoRepeat">
+                                 <bool>true</bool>
+                                </property>
+                               </widget>
+                              </item>
+                              <item row="1" column="0">
+                               <widget class="QPushButton" name="xy_div_10_pb">
+                                <property name="sizePolicy">
+                                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                 </sizepolicy>
+                                </property>
+                                <property name="minimumSize">
+                                 <size>
+                                  <width>50</width>
+                                  <height>23</height>
+                                 </size>
+                                </property>
+                                <property name="maximumSize">
+                                 <size>
+                                  <width>50</width>
+                                  <height>23</height>
+                                 </size>
+                                </property>
+                                <property name="font">
+                                 <font>
+                                  <bold>true</bold>
+                                 </font>
+                                </property>
+                                <property name="text">
+                                 <string>÷10</string>
+                                </property>
+                                <property name="autoRepeat">
+                                 <bool>false</bool>
+                                </property>
+                               </widget>
+                              </item>
+                              <item row="1" column="1">
+                               <widget class="QDoubleSpinBox" name="xy_step_val_dsb">
+                                <property name="sizePolicy">
+                                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                 </sizepolicy>
+                                </property>
+                                <property name="minimumSize">
+                                 <size>
+                                  <width>70</width>
+                                  <height>23</height>
+                                 </size>
+                                </property>
+                                <property name="maximumSize">
+                                 <size>
+                                  <width>70</width>
+                                  <height>23</height>
+                                 </size>
+                                </property>
+                                <property name="font">
+                                 <font>
+                                  <bold>true</bold>
+                                 </font>
+                                </property>
+                                <property name="alignment">
+                                 <set>Qt::AlignmentFlag::AlignCenter</set>
+                                </property>
+                                <property name="buttonSymbols">
+                                 <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                                </property>
+                                <property name="minimum">
+                                 <double>0.010000000000000</double>
+                                </property>
+                                <property name="maximum">
+                                 <double>1000.000000000000000</double>
+                                </property>
+                                <property name="singleStep">
+                                 <double>0.100000000000000</double>
+                                </property>
+                                <property name="value">
+                                 <double>0.100000000000000</double>
+                                </property>
+                               </widget>
+                              </item>
+                              <item row="1" column="2">
+                               <widget class="QPushButton" name="xy_mul_10_pb">
+                                <property name="sizePolicy">
+                                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                 </sizepolicy>
+                                </property>
+                                <property name="minimumSize">
+                                 <size>
+                                  <width>50</width>
+                                  <height>23</height>
+                                 </size>
+                                </property>
+                                <property name="maximumSize">
+                                 <size>
+                                  <width>50</width>
+                                  <height>23</height>
+                                 </size>
+                                </property>
+                                <property name="font">
+                                 <font>
+                                  <pointsize>8</pointsize>
+                                  <bold>true</bold>
+                                 </font>
+                                </property>
+                                <property name="text">
+                                 <string>x10</string>
+                                </property>
+                                <property name="autoRepeat">
+                                 <bool>false</bool>
+                                </property>
+                               </widget>
+                              </item>
+                              <item row="2" column="1">
+                               <widget class="QPushButton" name="xy_minus_1_pb">
+                                <property name="sizePolicy">
+                                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                  <horstretch>0</horstretch>
+                                  <verstretch>0</verstretch>
+                                 </sizepolicy>
+                                </property>
+                                <property name="minimumSize">
+                                 <size>
+                                  <width>70</width>
+                                  <height>23</height>
+                                 </size>
+                                </property>
+                                <property name="maximumSize">
+                                 <size>
+                                  <width>70</width>
+                                  <height>23</height>
+                                 </size>
+                                </property>
+                                <property name="font">
+                                 <font>
+                                  <bold>true</bold>
+                                 </font>
+                                </property>
+                                <property name="text">
+                                 <string>-1.0</string>
+                                </property>
+                                <property name="autoRepeat">
+                                 <bool>true</bool>
+                                </property>
+                               </widget>
+                              </item>
+                             </layout>
+                            </item>
+                           </layout>
+                          </item>
+                          <item row="1" column="1">
+                           <widget class="Line" name="line_2">
+                            <property name="lineWidth">
+                             <number>1</number>
+                            </property>
+                            <property name="orientation">
+                             <enum>Qt::Orientation::Horizontal</enum>
+                            </property>
+                           </widget>
+                          </item>
+                          <item row="1" column="0">
+                           <widget class="Line" name="line_5">
+                            <property name="orientation">
+                             <enum>Qt::Orientation::Horizontal</enum>
+                            </property>
+                           </widget>
+                          </item>
+                         </layout>
+                        </item>
+                        <item>
+                         <spacer name="verticalSpacer_7">
+                          <property name="orientation">
+                           <enum>Qt::Orientation::Vertical</enum>
+                          </property>
+                          <property name="sizeHint" stdset="0">
+                           <size>
+                            <width>20</width>
+                            <height>40</height>
+                           </size>
+                          </property>
+                         </spacer>
+                        </item>
+                       </layout>
                       </item>
                      </layout>
-                    </item>
-                   </layout>
-                  </item>
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_9">
-                    <item>
-                     <widget class="QPushButton" name="clear_terminal_pb">
-                      <property name="enabled">
-                       <bool>true</bool>
-                      </property>
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="font">
-                       <font>
-                        <bold>true</bold>
-                       </font>
-                      </property>
-                      <property name="text">
-                       <string>Clear Terminal</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <spacer name="horizontalSpacer_2">
-                      <property name="orientation">
-                       <enum>Qt::Orientation::Horizontal</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>40</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                    <item>
-                     <widget class="QPushButton" name="connect_pb">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="font">
-                       <font>
-                        <bold>true</bold>
-                       </font>
-                      </property>
-                      <property name="statusTip">
-                       <string>Connect to selected serial port.</string>
-                      </property>
-                      <property name="text">
-                       <string>Connect</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
+                    </widget>
+                    <widget class="QWidget" name="tabWidgetPage2" native="true">
+                     <attribute name="title">
+                      <string>Probe/Terminal</string>
+                     </attribute>
+                     <layout class="QVBoxLayout" name="verticalLayout_17">
+                      <item>
+                       <layout class="QGridLayout" name="probeABLGridLayout">
+                        <property name="leftMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="topMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="rightMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="bottomMargin">
+                         <number>0</number>
+                        </property>
+                        <item row="0" column="0" alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                         <widget class="QPushButton" name="probe_pb">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="minimumSize">
+                           <size>
+                            <width>0</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>23</height>
+                           </size>
+                          </property>
+                          <property name="text">
+                           <string>PROBE</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="2" alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                         <widget class="QPushButton" name="get_bbox_pb">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="minimumSize">
+                           <size>
+                            <width>0</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>23</height>
+                           </size>
+                          </property>
+                          <property name="font">
+                           <font>
+                            <bold>true</bold>
+                           </font>
+                          </property>
+                          <property name="text">
+                           <string>GET BBOX</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="1">
+                         <layout class="QHBoxLayout" name="horizontalLayout_11">
+                          <item>
+                           <widget class="QPushButton" name="ABL_pb">
+                            <property name="sizePolicy">
+                             <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
+                              <horstretch>0</horstretch>
+                              <verstretch>0</verstretch>
+                             </sizepolicy>
+                            </property>
+                            <property name="minimumSize">
+                             <size>
+                              <width>0</width>
+                              <height>20</height>
+                             </size>
+                            </property>
+                            <property name="maximumSize">
+                             <size>
+                              <width>16777215</width>
+                              <height>23</height>
+                             </size>
+                            </property>
+                            <property name="font">
+                             <font>
+                              <bold>true</bold>
+                             </font>
+                            </property>
+                            <property name="text">
+                             <string>ABL</string>
+                            </property>
+                           </widget>
+                          </item>
+                          <item>
+                           <widget class="QCheckBox" name="abl_active_chb">
+                            <property name="sizePolicy">
+                             <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
+                              <horstretch>0</horstretch>
+                              <verstretch>0</verstretch>
+                             </sizepolicy>
+                            </property>
+                            <property name="minimumSize">
+                             <size>
+                              <width>0</width>
+                              <height>20</height>
+                             </size>
+                            </property>
+                            <property name="maximumSize">
+                             <size>
+                              <width>16777215</width>
+                              <height>23</height>
+                             </size>
+                            </property>
+                            <property name="toolTip">
+                             <string>Apply ABL if checked</string>
+                            </property>
+                            <property name="text">
+                             <string/>
+                            </property>
+                            <property name="checked">
+                             <bool>true</bool>
+                            </property>
+                           </widget>
+                          </item>
+                         </layout>
+                        </item>
+                       </layout>
+                      </item>
+                      <item>
+                       <widget class="Line" name="line_3">
+                        <property name="orientation">
+                         <enum>Qt::Orientation::Horizontal</enum>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <layout class="QGridLayout" name="stepsGridLayout">
+                        <property name="verticalSpacing">
+                         <number>0</number>
+                        </property>
+                        <item row="0" column="1">
+                         <widget class="QLabel" name="min_l">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="minimumSize">
+                           <size>
+                            <width>0</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>23</height>
+                           </size>
+                          </property>
+                          <property name="font">
+                           <font>
+                            <bold>true</bold>
+                           </font>
+                          </property>
+                          <property name="text">
+                           <string>Min</string>
+                          </property>
+                          <property name="alignment">
+                           <set>Qt::AlignmentFlag::AlignCenter</set>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="2">
+                         <widget class="QLabel" name="max_l">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="minimumSize">
+                           <size>
+                            <width>0</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>23</height>
+                           </size>
+                          </property>
+                          <property name="font">
+                           <font>
+                            <bold>true</bold>
+                           </font>
+                          </property>
+                          <property name="text">
+                           <string>Max</string>
+                          </property>
+                          <property name="alignment">
+                           <set>Qt::AlignmentFlag::AlignCenter</set>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="3">
+                         <widget class="QLabel" name="step_l">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="minimumSize">
+                           <size>
+                            <width>0</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>23</height>
+                           </size>
+                          </property>
+                          <property name="font">
+                           <font>
+                            <bold>true</bold>
+                           </font>
+                          </property>
+                          <property name="text">
+                           <string>Step</string>
+                          </property>
+                          <property name="alignment">
+                           <set>Qt::AlignmentFlag::AlignCenter</set>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="4">
+                         <widget class="QLabel" name="n_step_l">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="minimumSize">
+                           <size>
+                            <width>0</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>23</height>
+                           </size>
+                          </property>
+                          <property name="font">
+                           <font>
+                            <bold>true</bold>
+                           </font>
+                          </property>
+                          <property name="text">
+                           <string>N</string>
+                          </property>
+                          <property name="alignment">
+                           <set>Qt::AlignmentFlag::AlignCenter</set>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="0">
+                         <widget class="QLabel" name="x_l">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="minimumSize">
+                           <size>
+                            <width>0</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>23</height>
+                           </size>
+                          </property>
+                          <property name="font">
+                           <font>
+                            <bold>true</bold>
+                           </font>
+                          </property>
+                          <property name="text">
+                           <string>X</string>
+                          </property>
+                          <property name="alignment">
+                           <set>Qt::AlignmentFlag::AlignCenter</set>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="1">
+                         <widget class="QDoubleSpinBox" name="x_min_dsb">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="minimumSize">
+                           <size>
+                            <width>0</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>23</height>
+                           </size>
+                          </property>
+                          <property name="alignment">
+                           <set>Qt::AlignmentFlag::AlignCenter</set>
+                          </property>
+                          <property name="buttonSymbols">
+                           <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                          </property>
+                          <property name="minimum">
+                           <double>-1000.000000000000000</double>
+                          </property>
+                          <property name="maximum">
+                           <double>1000.000000000000000</double>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="2">
+                         <widget class="QDoubleSpinBox" name="x_max_dsb">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="minimumSize">
+                           <size>
+                            <width>0</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>23</height>
+                           </size>
+                          </property>
+                          <property name="alignment">
+                           <set>Qt::AlignmentFlag::AlignCenter</set>
+                          </property>
+                          <property name="buttonSymbols">
+                           <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                          </property>
+                          <property name="minimum">
+                           <double>-1000.000000000000000</double>
+                          </property>
+                          <property name="maximum">
+                           <double>1000.000000000000000</double>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="3">
+                         <widget class="QDoubleSpinBox" name="x_step_dsb">
+                          <property name="enabled">
+                           <bool>false</bool>
+                          </property>
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="minimumSize">
+                           <size>
+                            <width>0</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>23</height>
+                           </size>
+                          </property>
+                          <property name="alignment">
+                           <set>Qt::AlignmentFlag::AlignCenter</set>
+                          </property>
+                          <property name="readOnly">
+                           <bool>true</bool>
+                          </property>
+                          <property name="buttonSymbols">
+                           <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="4">
+                         <widget class="QSpinBox" name="x_num_step_sb">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="minimumSize">
+                           <size>
+                            <width>0</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>23</height>
+                           </size>
+                          </property>
+                          <property name="alignment">
+                           <set>Qt::AlignmentFlag::AlignCenter</set>
+                          </property>
+                          <property name="minimum">
+                           <number>4</number>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="2" column="0">
+                         <widget class="QLabel" name="y_l">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="minimumSize">
+                           <size>
+                            <width>0</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>23</height>
+                           </size>
+                          </property>
+                          <property name="font">
+                           <font>
+                            <bold>true</bold>
+                           </font>
+                          </property>
+                          <property name="text">
+                           <string>Y</string>
+                          </property>
+                          <property name="alignment">
+                           <set>Qt::AlignmentFlag::AlignCenter</set>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="2" column="1">
+                         <widget class="QDoubleSpinBox" name="y_min_dsb">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="minimumSize">
+                           <size>
+                            <width>0</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>23</height>
+                           </size>
+                          </property>
+                          <property name="alignment">
+                           <set>Qt::AlignmentFlag::AlignCenter</set>
+                          </property>
+                          <property name="buttonSymbols">
+                           <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                          </property>
+                          <property name="minimum">
+                           <double>-1000.000000000000000</double>
+                          </property>
+                          <property name="maximum">
+                           <double>1000.000000000000000</double>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="2" column="2">
+                         <widget class="QDoubleSpinBox" name="y_max_dsb">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="minimumSize">
+                           <size>
+                            <width>0</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>23</height>
+                           </size>
+                          </property>
+                          <property name="alignment">
+                           <set>Qt::AlignmentFlag::AlignCenter</set>
+                          </property>
+                          <property name="buttonSymbols">
+                           <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                          </property>
+                          <property name="minimum">
+                           <double>-1000.000000000000000</double>
+                          </property>
+                          <property name="maximum">
+                           <double>1000.000000000000000</double>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="2" column="3">
+                         <widget class="QDoubleSpinBox" name="y_step_dsb">
+                          <property name="enabled">
+                           <bool>false</bool>
+                          </property>
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="minimumSize">
+                           <size>
+                            <width>0</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>23</height>
+                           </size>
+                          </property>
+                          <property name="alignment">
+                           <set>Qt::AlignmentFlag::AlignCenter</set>
+                          </property>
+                          <property name="readOnly">
+                           <bool>true</bool>
+                          </property>
+                          <property name="buttonSymbols">
+                           <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="2" column="4">
+                         <widget class="QSpinBox" name="y_num_step_sb">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="minimumSize">
+                           <size>
+                            <width>0</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>23</height>
+                           </size>
+                          </property>
+                          <property name="alignment">
+                           <set>Qt::AlignmentFlag::AlignCenter</set>
+                          </property>
+                          <property name="minimum">
+                           <number>4</number>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="3" column="0">
+                         <widget class="QLabel" name="z_l">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="minimumSize">
+                           <size>
+                            <width>0</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>23</height>
+                           </size>
+                          </property>
+                          <property name="font">
+                           <font>
+                            <bold>true</bold>
+                           </font>
+                          </property>
+                          <property name="text">
+                           <string>Z</string>
+                          </property>
+                          <property name="alignment">
+                           <set>Qt::AlignmentFlag::AlignCenter</set>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="3" column="1">
+                         <widget class="QDoubleSpinBox" name="z_min_dsb">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="minimumSize">
+                           <size>
+                            <width>0</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>23</height>
+                           </size>
+                          </property>
+                          <property name="alignment">
+                           <set>Qt::AlignmentFlag::AlignCenter</set>
+                          </property>
+                          <property name="buttonSymbols">
+                           <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                          </property>
+                          <property name="minimum">
+                           <double>-1000.000000000000000</double>
+                          </property>
+                          <property name="maximum">
+                           <double>1000.000000000000000</double>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="3" column="2">
+                         <widget class="QDoubleSpinBox" name="z_max_dsb">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="minimumSize">
+                           <size>
+                            <width>0</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>23</height>
+                           </size>
+                          </property>
+                          <property name="alignment">
+                           <set>Qt::AlignmentFlag::AlignCenter</set>
+                          </property>
+                          <property name="buttonSymbols">
+                           <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                          </property>
+                          <property name="minimum">
+                           <double>-1000.000000000000000</double>
+                          </property>
+                          <property name="maximum">
+                           <double>1000.000000000000000</double>
+                          </property>
+                         </widget>
+                        </item>
+                       </layout>
+                      </item>
+                      <item>
+                       <widget class="Line" name="line_4">
+                        <property name="orientation">
+                         <enum>Qt::Orientation::Horizontal</enum>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QTextEdit" name="serial_te">
+                        <property name="enabled">
+                         <bool>true</bool>
+                        </property>
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="minimumSize">
+                         <size>
+                          <width>0</width>
+                          <height>40</height>
+                         </size>
+                        </property>
+                        <property name="frameShadow">
+                         <enum>QFrame::Shadow::Sunken</enum>
+                        </property>
+                        <property name="verticalScrollBarPolicy">
+                         <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOn</enum>
+                        </property>
+                        <property name="textInteractionFlags">
+                         <set>Qt::TextInteractionFlag::TextSelectableByKeyboard|Qt::TextInteractionFlag::TextSelectableByMouse</set>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <layout class="QHBoxLayout" name="horizontalLayout_2">
+                        <item>
+                         <widget class="ComboBoxFilterEnter" name="send_cb">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="autoFillBackground">
+                           <bool>true</bool>
+                          </property>
+                          <property name="editable">
+                           <bool>true</bool>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <widget class="QPushButton" name="send_pb">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="font">
+                           <font>
+                            <bold>true</bold>
+                           </font>
+                          </property>
+                          <property name="text">
+                           <string>Send</string>
+                          </property>
+                         </widget>
+                        </item>
+                       </layout>
+                      </item>
+                      <item>
+                       <layout class="QVBoxLayout" name="connectVerticalLayout">
+                        <property name="spacing">
+                         <number>6</number>
+                        </property>
+                        <property name="leftMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="topMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="rightMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="bottomMargin">
+                         <number>0</number>
+                        </property>
+                        <item>
+                         <layout class="QHBoxLayout" name="horizontalLayout">
+                          <property name="spacing">
+                           <number>6</number>
+                          </property>
+                          <item>
+                           <widget class="QComboBox" name="serial_ports_cb">
+                            <property name="sizePolicy">
+                             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                              <horstretch>0</horstretch>
+                              <verstretch>0</verstretch>
+                             </sizepolicy>
+                            </property>
+                            <property name="toolTip">
+                             <string>Available serial ports.</string>
+                            </property>
+                            <property name="statusTip">
+                             <string>Available serial ports.</string>
+                            </property>
+                           </widget>
+                          </item>
+                          <item>
+                           <widget class="QComboBox" name="serial_baud_cb">
+                            <property name="sizePolicy">
+                             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                              <horstretch>0</horstretch>
+                              <verstretch>0</verstretch>
+                             </sizepolicy>
+                            </property>
+                            <property name="toolTip">
+                             <string>Serial port baudrate [bps]</string>
+                            </property>
+                            <property name="statusTip">
+                             <string>Serial port baudrate [bps]</string>
+                            </property>
+                            <property name="currentText">
+                             <string/>
+                            </property>
+                           </widget>
+                          </item>
+                          <item>
+                           <widget class="QPushButton" name="refresh_pb">
+                            <property name="sizePolicy">
+                             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                              <horstretch>0</horstretch>
+                              <verstretch>0</verstretch>
+                             </sizepolicy>
+                            </property>
+                            <property name="font">
+                             <font>
+                              <bold>true</bold>
+                             </font>
+                            </property>
+                            <property name="statusTip">
+                             <string>Refresh serial port list.</string>
+                            </property>
+                            <property name="text">
+                             <string>Serial Ports Refresh</string>
+                            </property>
+                            <property name="checkable">
+                             <bool>false</bool>
+                            </property>
+                           </widget>
+                          </item>
+                         </layout>
+                        </item>
+                       </layout>
+                      </item>
+                      <item>
+                       <layout class="QHBoxLayout" name="horizontalLayout_9">
+                        <item>
+                         <widget class="QPushButton" name="clear_terminal_pb">
+                          <property name="enabled">
+                           <bool>true</bool>
+                          </property>
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="font">
+                           <font>
+                            <bold>true</bold>
+                           </font>
+                          </property>
+                          <property name="text">
+                           <string>Clear Terminal</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <spacer name="horizontalSpacer_2">
+                          <property name="orientation">
+                           <enum>Qt::Orientation::Horizontal</enum>
+                          </property>
+                          <property name="sizeHint" stdset="0">
+                           <size>
+                            <width>40</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                         </spacer>
+                        </item>
+                        <item>
+                         <widget class="QPushButton" name="connect_pb">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="font">
+                           <font>
+                            <bold>true</bold>
+                           </font>
+                          </property>
+                          <property name="statusTip">
+                           <string>Connect to selected serial port.</string>
+                          </property>
+                          <property name="text">
+                           <string>Connect</string>
+                          </property>
+                         </widget>
+                        </item>
+                       </layout>
+                      </item>
+                     </layout>
+                    </widget>
+                   </widget>
                   </item>
                  </layout>
                 </item>

--- a/src/TheAntFarm/ui_manager/ui_manager.py
+++ b/src/TheAntFarm/ui_manager/ui_manager.py
@@ -79,6 +79,7 @@ class UiManager(QObject):
         self.main_win.ui.main_tab_widget.setCurrentIndex(app_settings.main_tab_index)
         self.main_win.ui.ctrl_tab_widget.setCurrentIndex(app_settings.ctrl_tab_index)
         self.main_win.ui.settings_sub_tab.setCurrentIndex(app_settings.settings_tab_index)
+        self.main_win.ui.jog_probe_tab_widget.setCurrentIndex(app_settings.jog_probe_tab_index)
 
     def save_all_settings(self):
         """ Saves all settings in the configuration files. """

--- a/src/TheAntFarm/ui_the_ant_farm.py
+++ b/src/TheAntFarm/ui_the_ant_farm.py
@@ -1523,20 +1523,20 @@ class Ui_MainWindow(object):
 
         self.terminalVerticalLayout = QVBoxLayout()
         self.terminalVerticalLayout.setObjectName(u"terminalVerticalLayout")
-        self.tabWidget = QTabWidget(self.sender_tab)
-        self.tabWidget.setObjectName(u"tabWidget")
+        self.jog_probe_tab_widget = QTabWidget(self.sender_tab)
+        self.jog_probe_tab_widget.setObjectName(u"jog_probe_tab_widget")
         sizePolicy8 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
         sizePolicy8.setHorizontalStretch(0)
         sizePolicy8.setVerticalStretch(0)
-        sizePolicy8.setHeightForWidth(self.tabWidget.sizePolicy().hasHeightForWidth())
-        self.tabWidget.setSizePolicy(sizePolicy8)
-        self.tabWidget.setMinimumSize(QSize(0, 0))
-        self.tabWidget.setTabPosition(QTabWidget.TabPosition.South)
-        self.tabWidget.setTabBarAutoHide(True)
-        self.tab = QWidget()
-        self.tab.setObjectName(u"tab")
-        self.tab.setEnabled(True)
-        self.horizontalLayout_19 = QHBoxLayout(self.tab)
+        sizePolicy8.setHeightForWidth(self.jog_probe_tab_widget.sizePolicy().hasHeightForWidth())
+        self.jog_probe_tab_widget.setSizePolicy(sizePolicy8)
+        self.jog_probe_tab_widget.setMinimumSize(QSize(0, 0))
+        self.jog_probe_tab_widget.setTabPosition(QTabWidget.TabPosition.South)
+        self.jog_probe_tab_widget.setTabBarAutoHide(True)
+        self.jog_tab = QWidget()
+        self.jog_tab.setObjectName(u"jog_tab")
+        self.jog_tab.setEnabled(True)
+        self.horizontalLayout_19 = QHBoxLayout(self.jog_tab)
         self.horizontalLayout_19.setObjectName(u"horizontalLayout_19")
         self.verticalLayout_18 = QVBoxLayout()
         self.verticalLayout_18.setObjectName(u"verticalLayout_18")
@@ -1545,7 +1545,7 @@ class Ui_MainWindow(object):
         self.zMoveGridLayout = QGridLayout()
         self.zMoveGridLayout.setObjectName(u"zMoveGridLayout")
         self.zMoveGridLayout.setSizeConstraint(QLayout.SizeConstraint.SetDefaultConstraint)
-        self.z_plus_pb = QPushButton(self.tab)
+        self.z_plus_pb = QPushButton(self.jog_tab)
         self.z_plus_pb.setObjectName(u"z_plus_pb")
         sizePolicy3.setHeightForWidth(self.z_plus_pb.sizePolicy().hasHeightForWidth())
         self.z_plus_pb.setSizePolicy(sizePolicy3)
@@ -1557,7 +1557,7 @@ class Ui_MainWindow(object):
 
         self.zMoveGridLayout.addWidget(self.z_plus_pb, 0, 0, 1, 1)
 
-        self.z_minus_pb = QPushButton(self.tab)
+        self.z_minus_pb = QPushButton(self.jog_tab)
         self.z_minus_pb.setObjectName(u"z_minus_pb")
         sizePolicy3.setHeightForWidth(self.z_minus_pb.sizePolicy().hasHeightForWidth())
         self.z_minus_pb.setSizePolicy(sizePolicy3)
@@ -1575,7 +1575,7 @@ class Ui_MainWindow(object):
         self.xyMoveGridLayout = QGridLayout()
         self.xyMoveGridLayout.setObjectName(u"xyMoveGridLayout")
         self.xyMoveGridLayout.setContentsMargins(0, 0, 0, 0)
-        self.x_minus_y_plus_pb = QToolButton(self.tab)
+        self.x_minus_y_plus_pb = QToolButton(self.jog_tab)
         self.x_minus_y_plus_pb.setObjectName(u"x_minus_y_plus_pb")
         sizePolicy3.setHeightForWidth(self.x_minus_y_plus_pb.sizePolicy().hasHeightForWidth())
         self.x_minus_y_plus_pb.setSizePolicy(sizePolicy3)
@@ -1587,7 +1587,7 @@ class Ui_MainWindow(object):
 
         self.xyMoveGridLayout.addWidget(self.x_minus_y_plus_pb, 0, 0, 1, 1)
 
-        self.x_plus_y_minus_pb = QToolButton(self.tab)
+        self.x_plus_y_minus_pb = QToolButton(self.jog_tab)
         self.x_plus_y_minus_pb.setObjectName(u"x_plus_y_minus_pb")
         sizePolicy3.setHeightForWidth(self.x_plus_y_minus_pb.sizePolicy().hasHeightForWidth())
         self.x_plus_y_minus_pb.setSizePolicy(sizePolicy3)
@@ -1599,7 +1599,7 @@ class Ui_MainWindow(object):
 
         self.xyMoveGridLayout.addWidget(self.x_plus_y_minus_pb, 2, 2, 1, 1)
 
-        self.x_minus_pb = QToolButton(self.tab)
+        self.x_minus_pb = QToolButton(self.jog_tab)
         self.x_minus_pb.setObjectName(u"x_minus_pb")
         sizePolicy3.setHeightForWidth(self.x_minus_pb.sizePolicy().hasHeightForWidth())
         self.x_minus_pb.setSizePolicy(sizePolicy3)
@@ -1611,7 +1611,7 @@ class Ui_MainWindow(object):
 
         self.xyMoveGridLayout.addWidget(self.x_minus_pb, 1, 0, 1, 1)
 
-        self.x_minus_y_minus_pb = QToolButton(self.tab)
+        self.x_minus_y_minus_pb = QToolButton(self.jog_tab)
         self.x_minus_y_minus_pb.setObjectName(u"x_minus_y_minus_pb")
         sizePolicy3.setHeightForWidth(self.x_minus_y_minus_pb.sizePolicy().hasHeightForWidth())
         self.x_minus_y_minus_pb.setSizePolicy(sizePolicy3)
@@ -1623,7 +1623,7 @@ class Ui_MainWindow(object):
 
         self.xyMoveGridLayout.addWidget(self.x_minus_y_minus_pb, 2, 0, 1, 1)
 
-        self.y_plus_pb = QToolButton(self.tab)
+        self.y_plus_pb = QToolButton(self.jog_tab)
         self.y_plus_pb.setObjectName(u"y_plus_pb")
         sizePolicy3.setHeightForWidth(self.y_plus_pb.sizePolicy().hasHeightForWidth())
         self.y_plus_pb.setSizePolicy(sizePolicy3)
@@ -1633,7 +1633,7 @@ class Ui_MainWindow(object):
 
         self.xyMoveGridLayout.addWidget(self.y_plus_pb, 0, 1, 1, 1)
 
-        self.center_tb = QToolButton(self.tab)
+        self.center_tb = QToolButton(self.jog_tab)
         self.center_tb.setObjectName(u"center_tb")
         sizePolicy3.setHeightForWidth(self.center_tb.sizePolicy().hasHeightForWidth())
         self.center_tb.setSizePolicy(sizePolicy3)
@@ -1645,7 +1645,7 @@ class Ui_MainWindow(object):
 
         self.xyMoveGridLayout.addWidget(self.center_tb, 1, 1, 1, 1)
 
-        self.y_minus_pb = QToolButton(self.tab)
+        self.y_minus_pb = QToolButton(self.jog_tab)
         self.y_minus_pb.setObjectName(u"y_minus_pb")
         sizePolicy3.setHeightForWidth(self.y_minus_pb.sizePolicy().hasHeightForWidth())
         self.y_minus_pb.setSizePolicy(sizePolicy3)
@@ -1655,7 +1655,7 @@ class Ui_MainWindow(object):
 
         self.xyMoveGridLayout.addWidget(self.y_minus_pb, 2, 1, 1, 1)
 
-        self.x_plus_y_plus_pb = QToolButton(self.tab)
+        self.x_plus_y_plus_pb = QToolButton(self.jog_tab)
         self.x_plus_y_plus_pb.setObjectName(u"x_plus_y_plus_pb")
         sizePolicy3.setHeightForWidth(self.x_plus_y_plus_pb.sizePolicy().hasHeightForWidth())
         self.x_plus_y_plus_pb.setSizePolicy(sizePolicy3)
@@ -1667,7 +1667,7 @@ class Ui_MainWindow(object):
 
         self.xyMoveGridLayout.addWidget(self.x_plus_y_plus_pb, 0, 2, 1, 1)
 
-        self.x_plus_pb = QToolButton(self.tab)
+        self.x_plus_pb = QToolButton(self.jog_tab)
         self.x_plus_pb.setObjectName(u"x_plus_pb")
         sizePolicy3.setHeightForWidth(self.x_plus_pb.sizePolicy().hasHeightForWidth())
         self.x_plus_pb.setSizePolicy(sizePolicy3)
@@ -1687,7 +1687,7 @@ class Ui_MainWindow(object):
         self.horizontalLayout_14 = QHBoxLayout()
         self.horizontalLayout_14.setObjectName(u"horizontalLayout_14")
         self.horizontalLayout_14.setSizeConstraint(QLayout.SizeConstraint.SetDefaultConstraint)
-        self.z_jog_l_2 = QLabel(self.tab)
+        self.z_jog_l_2 = QLabel(self.jog_tab)
         self.z_jog_l_2.setObjectName(u"z_jog_l_2")
         sizePolicy3.setHeightForWidth(self.z_jog_l_2.sizePolicy().hasHeightForWidth())
         self.z_jog_l_2.setSizePolicy(sizePolicy3)
@@ -1698,7 +1698,7 @@ class Ui_MainWindow(object):
 
         self.horizontalLayout_14.addWidget(self.z_jog_l_2, 0, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
 
-        self.z_step_cb = QComboBox(self.tab)
+        self.z_step_cb = QComboBox(self.jog_tab)
         self.z_step_cb.addItem("")
         self.z_step_cb.addItem("")
         self.z_step_cb.addItem("")
@@ -1721,7 +1721,7 @@ class Ui_MainWindow(object):
 
         self.gridLayout_18 = QGridLayout()
         self.gridLayout_18.setObjectName(u"gridLayout_18")
-        self.z_step_val_dsb = QDoubleSpinBox(self.tab)
+        self.z_step_val_dsb = QDoubleSpinBox(self.jog_tab)
         self.z_step_val_dsb.setObjectName(u"z_step_val_dsb")
         self.z_step_val_dsb.setMinimumSize(QSize(70, 20))
         self.z_step_val_dsb.setMaximumSize(QSize(70, 16777215))
@@ -1735,7 +1735,7 @@ class Ui_MainWindow(object):
 
         self.gridLayout_18.addWidget(self.z_step_val_dsb, 1, 1, 1, 1)
 
-        self.z_mul_10_pb = QPushButton(self.tab)
+        self.z_mul_10_pb = QPushButton(self.jog_tab)
         self.z_mul_10_pb.setObjectName(u"z_mul_10_pb")
         sizePolicy3.setHeightForWidth(self.z_mul_10_pb.sizePolicy().hasHeightForWidth())
         self.z_mul_10_pb.setSizePolicy(sizePolicy3)
@@ -1749,7 +1749,7 @@ class Ui_MainWindow(object):
 
         self.gridLayout_18.addWidget(self.z_mul_10_pb, 1, 2, 1, 1)
 
-        self.z_div_10_pb = QPushButton(self.tab)
+        self.z_div_10_pb = QPushButton(self.jog_tab)
         self.z_div_10_pb.setObjectName(u"z_div_10_pb")
         sizePolicy3.setHeightForWidth(self.z_div_10_pb.sizePolicy().hasHeightForWidth())
         self.z_div_10_pb.setSizePolicy(sizePolicy3)
@@ -1760,7 +1760,7 @@ class Ui_MainWindow(object):
 
         self.gridLayout_18.addWidget(self.z_div_10_pb, 1, 0, 1, 1)
 
-        self.z_minus_1_pb = QPushButton(self.tab)
+        self.z_minus_1_pb = QPushButton(self.jog_tab)
         self.z_minus_1_pb.setObjectName(u"z_minus_1_pb")
         sizePolicy3.setHeightForWidth(self.z_minus_1_pb.sizePolicy().hasHeightForWidth())
         self.z_minus_1_pb.setSizePolicy(sizePolicy3)
@@ -1771,7 +1771,7 @@ class Ui_MainWindow(object):
 
         self.gridLayout_18.addWidget(self.z_minus_1_pb, 2, 1, 1, 1)
 
-        self.z_plus_1_pb = QPushButton(self.tab)
+        self.z_plus_1_pb = QPushButton(self.jog_tab)
         self.z_plus_1_pb.setObjectName(u"z_plus_1_pb")
         sizePolicy3.setHeightForWidth(self.z_plus_1_pb.sizePolicy().hasHeightForWidth())
         self.z_plus_1_pb.setSizePolicy(sizePolicy3)
@@ -1793,7 +1793,7 @@ class Ui_MainWindow(object):
         self.horizontalLayout_12 = QHBoxLayout()
         self.horizontalLayout_12.setObjectName(u"horizontalLayout_12")
         self.horizontalLayout_12.setSizeConstraint(QLayout.SizeConstraint.SetDefaultConstraint)
-        self.xy_jog_l = QLabel(self.tab)
+        self.xy_jog_l = QLabel(self.jog_tab)
         self.xy_jog_l.setObjectName(u"xy_jog_l")
         sizePolicy3.setHeightForWidth(self.xy_jog_l.sizePolicy().hasHeightForWidth())
         self.xy_jog_l.setSizePolicy(sizePolicy3)
@@ -1803,7 +1803,7 @@ class Ui_MainWindow(object):
 
         self.horizontalLayout_12.addWidget(self.xy_jog_l, 0, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
 
-        self.xy_step_cb = QComboBox(self.tab)
+        self.xy_step_cb = QComboBox(self.jog_tab)
         self.xy_step_cb.addItem("")
         self.xy_step_cb.addItem("")
         self.xy_step_cb.addItem("")
@@ -1825,7 +1825,7 @@ class Ui_MainWindow(object):
 
         self.gridLayout_16 = QGridLayout()
         self.gridLayout_16.setObjectName(u"gridLayout_16")
-        self.xy_plus_1_pb = QPushButton(self.tab)
+        self.xy_plus_1_pb = QPushButton(self.jog_tab)
         self.xy_plus_1_pb.setObjectName(u"xy_plus_1_pb")
         sizePolicy3.setHeightForWidth(self.xy_plus_1_pb.sizePolicy().hasHeightForWidth())
         self.xy_plus_1_pb.setSizePolicy(sizePolicy3)
@@ -1836,7 +1836,7 @@ class Ui_MainWindow(object):
 
         self.gridLayout_16.addWidget(self.xy_plus_1_pb, 0, 1, 1, 1)
 
-        self.xy_div_10_pb = QPushButton(self.tab)
+        self.xy_div_10_pb = QPushButton(self.jog_tab)
         self.xy_div_10_pb.setObjectName(u"xy_div_10_pb")
         sizePolicy3.setHeightForWidth(self.xy_div_10_pb.sizePolicy().hasHeightForWidth())
         self.xy_div_10_pb.setSizePolicy(sizePolicy3)
@@ -1847,7 +1847,7 @@ class Ui_MainWindow(object):
 
         self.gridLayout_16.addWidget(self.xy_div_10_pb, 1, 0, 1, 1)
 
-        self.xy_step_val_dsb = QDoubleSpinBox(self.tab)
+        self.xy_step_val_dsb = QDoubleSpinBox(self.jog_tab)
         self.xy_step_val_dsb.setObjectName(u"xy_step_val_dsb")
         sizePolicy3.setHeightForWidth(self.xy_step_val_dsb.sizePolicy().hasHeightForWidth())
         self.xy_step_val_dsb.setSizePolicy(sizePolicy3)
@@ -1863,7 +1863,7 @@ class Ui_MainWindow(object):
 
         self.gridLayout_16.addWidget(self.xy_step_val_dsb, 1, 1, 1, 1)
 
-        self.xy_mul_10_pb = QPushButton(self.tab)
+        self.xy_mul_10_pb = QPushButton(self.jog_tab)
         self.xy_mul_10_pb.setObjectName(u"xy_mul_10_pb")
         sizePolicy3.setHeightForWidth(self.xy_mul_10_pb.sizePolicy().hasHeightForWidth())
         self.xy_mul_10_pb.setSizePolicy(sizePolicy3)
@@ -1874,7 +1874,7 @@ class Ui_MainWindow(object):
 
         self.gridLayout_16.addWidget(self.xy_mul_10_pb, 1, 2, 1, 1)
 
-        self.xy_minus_1_pb = QPushButton(self.tab)
+        self.xy_minus_1_pb = QPushButton(self.jog_tab)
         self.xy_minus_1_pb.setObjectName(u"xy_minus_1_pb")
         sizePolicy3.setHeightForWidth(self.xy_minus_1_pb.sizePolicy().hasHeightForWidth())
         self.xy_minus_1_pb.setSizePolicy(sizePolicy3)
@@ -1891,7 +1891,7 @@ class Ui_MainWindow(object):
 
         self.jogGridlayout.addLayout(self.xyStepAdjustmentVerticalLayout, 0, 1, 1, 1)
 
-        self.line_2 = QFrame(self.tab)
+        self.line_2 = QFrame(self.jog_tab)
         self.line_2.setObjectName(u"line_2")
         self.line_2.setLineWidth(1)
         self.line_2.setFrameShape(QFrame.Shape.HLine)
@@ -1899,7 +1899,7 @@ class Ui_MainWindow(object):
 
         self.jogGridlayout.addWidget(self.line_2, 1, 1, 1, 1)
 
-        self.line_5 = QFrame(self.tab)
+        self.line_5 = QFrame(self.jog_tab)
         self.line_5.setObjectName(u"line_5")
         self.line_5.setFrameShape(QFrame.Shape.HLine)
         self.line_5.setFrameShadow(QFrame.Shadow.Sunken)
@@ -1916,15 +1916,15 @@ class Ui_MainWindow(object):
 
         self.horizontalLayout_19.addLayout(self.verticalLayout_18)
 
-        self.tabWidget.addTab(self.tab, "")
-        self.tabWidgetPage2 = QWidget()
-        self.tabWidgetPage2.setObjectName(u"tabWidgetPage2")
-        self.verticalLayout_17 = QVBoxLayout(self.tabWidgetPage2)
+        self.jog_probe_tab_widget.addTab(self.jog_tab, "")
+        self.probe_terminal_tab = QWidget()
+        self.probe_terminal_tab.setObjectName(u"probe_terminal_tab")
+        self.verticalLayout_17 = QVBoxLayout(self.probe_terminal_tab)
         self.verticalLayout_17.setObjectName(u"verticalLayout_17")
         self.probeABLGridLayout = QGridLayout()
         self.probeABLGridLayout.setObjectName(u"probeABLGridLayout")
         self.probeABLGridLayout.setContentsMargins(0, 0, 0, 0)
-        self.probe_pb = QPushButton(self.tabWidgetPage2)
+        self.probe_pb = QPushButton(self.probe_terminal_tab)
         self.probe_pb.setObjectName(u"probe_pb")
         sizePolicy7.setHeightForWidth(self.probe_pb.sizePolicy().hasHeightForWidth())
         self.probe_pb.setSizePolicy(sizePolicy7)
@@ -1933,7 +1933,7 @@ class Ui_MainWindow(object):
 
         self.probeABLGridLayout.addWidget(self.probe_pb, 0, 0, 1, 1, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
 
-        self.get_bbox_pb = QPushButton(self.tabWidgetPage2)
+        self.get_bbox_pb = QPushButton(self.probe_terminal_tab)
         self.get_bbox_pb.setObjectName(u"get_bbox_pb")
         sizePolicy7.setHeightForWidth(self.get_bbox_pb.sizePolicy().hasHeightForWidth())
         self.get_bbox_pb.setSizePolicy(sizePolicy7)
@@ -1945,7 +1945,7 @@ class Ui_MainWindow(object):
 
         self.horizontalLayout_11 = QHBoxLayout()
         self.horizontalLayout_11.setObjectName(u"horizontalLayout_11")
-        self.ABL_pb = QPushButton(self.tabWidgetPage2)
+        self.ABL_pb = QPushButton(self.probe_terminal_tab)
         self.ABL_pb.setObjectName(u"ABL_pb")
         sizePolicy7.setHeightForWidth(self.ABL_pb.sizePolicy().hasHeightForWidth())
         self.ABL_pb.setSizePolicy(sizePolicy7)
@@ -1955,7 +1955,7 @@ class Ui_MainWindow(object):
 
         self.horizontalLayout_11.addWidget(self.ABL_pb)
 
-        self.abl_active_chb = QCheckBox(self.tabWidgetPage2)
+        self.abl_active_chb = QCheckBox(self.probe_terminal_tab)
         self.abl_active_chb.setObjectName(u"abl_active_chb")
         sizePolicy9 = QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.MinimumExpanding)
         sizePolicy9.setHorizontalStretch(0)
@@ -1974,7 +1974,7 @@ class Ui_MainWindow(object):
 
         self.verticalLayout_17.addLayout(self.probeABLGridLayout)
 
-        self.line_3 = QFrame(self.tabWidgetPage2)
+        self.line_3 = QFrame(self.probe_terminal_tab)
         self.line_3.setObjectName(u"line_3")
         self.line_3.setFrameShape(QFrame.Shape.HLine)
         self.line_3.setFrameShadow(QFrame.Shadow.Sunken)
@@ -1984,7 +1984,7 @@ class Ui_MainWindow(object):
         self.stepsGridLayout = QGridLayout()
         self.stepsGridLayout.setObjectName(u"stepsGridLayout")
         self.stepsGridLayout.setVerticalSpacing(0)
-        self.min_l = QLabel(self.tabWidgetPage2)
+        self.min_l = QLabel(self.probe_terminal_tab)
         self.min_l.setObjectName(u"min_l")
         sizePolicy10 = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.MinimumExpanding)
         sizePolicy10.setHorizontalStretch(0)
@@ -1998,7 +1998,7 @@ class Ui_MainWindow(object):
 
         self.stepsGridLayout.addWidget(self.min_l, 0, 1, 1, 1)
 
-        self.max_l = QLabel(self.tabWidgetPage2)
+        self.max_l = QLabel(self.probe_terminal_tab)
         self.max_l.setObjectName(u"max_l")
         sizePolicy10.setHeightForWidth(self.max_l.sizePolicy().hasHeightForWidth())
         self.max_l.setSizePolicy(sizePolicy10)
@@ -2009,7 +2009,7 @@ class Ui_MainWindow(object):
 
         self.stepsGridLayout.addWidget(self.max_l, 0, 2, 1, 1)
 
-        self.step_l = QLabel(self.tabWidgetPage2)
+        self.step_l = QLabel(self.probe_terminal_tab)
         self.step_l.setObjectName(u"step_l")
         sizePolicy10.setHeightForWidth(self.step_l.sizePolicy().hasHeightForWidth())
         self.step_l.setSizePolicy(sizePolicy10)
@@ -2020,7 +2020,7 @@ class Ui_MainWindow(object):
 
         self.stepsGridLayout.addWidget(self.step_l, 0, 3, 1, 1)
 
-        self.n_step_l = QLabel(self.tabWidgetPage2)
+        self.n_step_l = QLabel(self.probe_terminal_tab)
         self.n_step_l.setObjectName(u"n_step_l")
         sizePolicy10.setHeightForWidth(self.n_step_l.sizePolicy().hasHeightForWidth())
         self.n_step_l.setSizePolicy(sizePolicy10)
@@ -2031,7 +2031,7 @@ class Ui_MainWindow(object):
 
         self.stepsGridLayout.addWidget(self.n_step_l, 0, 4, 1, 1)
 
-        self.x_l = QLabel(self.tabWidgetPage2)
+        self.x_l = QLabel(self.probe_terminal_tab)
         self.x_l.setObjectName(u"x_l")
         sizePolicy10.setHeightForWidth(self.x_l.sizePolicy().hasHeightForWidth())
         self.x_l.setSizePolicy(sizePolicy10)
@@ -2042,7 +2042,7 @@ class Ui_MainWindow(object):
 
         self.stepsGridLayout.addWidget(self.x_l, 1, 0, 1, 1)
 
-        self.x_min_dsb = QDoubleSpinBox(self.tabWidgetPage2)
+        self.x_min_dsb = QDoubleSpinBox(self.probe_terminal_tab)
         self.x_min_dsb.setObjectName(u"x_min_dsb")
         sizePolicy9.setHeightForWidth(self.x_min_dsb.sizePolicy().hasHeightForWidth())
         self.x_min_dsb.setSizePolicy(sizePolicy9)
@@ -2055,7 +2055,7 @@ class Ui_MainWindow(object):
 
         self.stepsGridLayout.addWidget(self.x_min_dsb, 1, 1, 1, 1)
 
-        self.x_max_dsb = QDoubleSpinBox(self.tabWidgetPage2)
+        self.x_max_dsb = QDoubleSpinBox(self.probe_terminal_tab)
         self.x_max_dsb.setObjectName(u"x_max_dsb")
         sizePolicy9.setHeightForWidth(self.x_max_dsb.sizePolicy().hasHeightForWidth())
         self.x_max_dsb.setSizePolicy(sizePolicy9)
@@ -2068,7 +2068,7 @@ class Ui_MainWindow(object):
 
         self.stepsGridLayout.addWidget(self.x_max_dsb, 1, 2, 1, 1)
 
-        self.x_step_dsb = QDoubleSpinBox(self.tabWidgetPage2)
+        self.x_step_dsb = QDoubleSpinBox(self.probe_terminal_tab)
         self.x_step_dsb.setObjectName(u"x_step_dsb")
         self.x_step_dsb.setEnabled(False)
         sizePolicy9.setHeightForWidth(self.x_step_dsb.sizePolicy().hasHeightForWidth())
@@ -2081,7 +2081,7 @@ class Ui_MainWindow(object):
 
         self.stepsGridLayout.addWidget(self.x_step_dsb, 1, 3, 1, 1)
 
-        self.x_num_step_sb = QSpinBox(self.tabWidgetPage2)
+        self.x_num_step_sb = QSpinBox(self.probe_terminal_tab)
         self.x_num_step_sb.setObjectName(u"x_num_step_sb")
         sizePolicy9.setHeightForWidth(self.x_num_step_sb.sizePolicy().hasHeightForWidth())
         self.x_num_step_sb.setSizePolicy(sizePolicy9)
@@ -2092,7 +2092,7 @@ class Ui_MainWindow(object):
 
         self.stepsGridLayout.addWidget(self.x_num_step_sb, 1, 4, 1, 1)
 
-        self.y_l = QLabel(self.tabWidgetPage2)
+        self.y_l = QLabel(self.probe_terminal_tab)
         self.y_l.setObjectName(u"y_l")
         sizePolicy10.setHeightForWidth(self.y_l.sizePolicy().hasHeightForWidth())
         self.y_l.setSizePolicy(sizePolicy10)
@@ -2103,7 +2103,7 @@ class Ui_MainWindow(object):
 
         self.stepsGridLayout.addWidget(self.y_l, 2, 0, 1, 1)
 
-        self.y_min_dsb = QDoubleSpinBox(self.tabWidgetPage2)
+        self.y_min_dsb = QDoubleSpinBox(self.probe_terminal_tab)
         self.y_min_dsb.setObjectName(u"y_min_dsb")
         sizePolicy9.setHeightForWidth(self.y_min_dsb.sizePolicy().hasHeightForWidth())
         self.y_min_dsb.setSizePolicy(sizePolicy9)
@@ -2116,7 +2116,7 @@ class Ui_MainWindow(object):
 
         self.stepsGridLayout.addWidget(self.y_min_dsb, 2, 1, 1, 1)
 
-        self.y_max_dsb = QDoubleSpinBox(self.tabWidgetPage2)
+        self.y_max_dsb = QDoubleSpinBox(self.probe_terminal_tab)
         self.y_max_dsb.setObjectName(u"y_max_dsb")
         sizePolicy9.setHeightForWidth(self.y_max_dsb.sizePolicy().hasHeightForWidth())
         self.y_max_dsb.setSizePolicy(sizePolicy9)
@@ -2129,7 +2129,7 @@ class Ui_MainWindow(object):
 
         self.stepsGridLayout.addWidget(self.y_max_dsb, 2, 2, 1, 1)
 
-        self.y_step_dsb = QDoubleSpinBox(self.tabWidgetPage2)
+        self.y_step_dsb = QDoubleSpinBox(self.probe_terminal_tab)
         self.y_step_dsb.setObjectName(u"y_step_dsb")
         self.y_step_dsb.setEnabled(False)
         sizePolicy9.setHeightForWidth(self.y_step_dsb.sizePolicy().hasHeightForWidth())
@@ -2142,7 +2142,7 @@ class Ui_MainWindow(object):
 
         self.stepsGridLayout.addWidget(self.y_step_dsb, 2, 3, 1, 1)
 
-        self.y_num_step_sb = QSpinBox(self.tabWidgetPage2)
+        self.y_num_step_sb = QSpinBox(self.probe_terminal_tab)
         self.y_num_step_sb.setObjectName(u"y_num_step_sb")
         sizePolicy9.setHeightForWidth(self.y_num_step_sb.sizePolicy().hasHeightForWidth())
         self.y_num_step_sb.setSizePolicy(sizePolicy9)
@@ -2153,7 +2153,7 @@ class Ui_MainWindow(object):
 
         self.stepsGridLayout.addWidget(self.y_num_step_sb, 2, 4, 1, 1)
 
-        self.z_l = QLabel(self.tabWidgetPage2)
+        self.z_l = QLabel(self.probe_terminal_tab)
         self.z_l.setObjectName(u"z_l")
         sizePolicy10.setHeightForWidth(self.z_l.sizePolicy().hasHeightForWidth())
         self.z_l.setSizePolicy(sizePolicy10)
@@ -2164,7 +2164,7 @@ class Ui_MainWindow(object):
 
         self.stepsGridLayout.addWidget(self.z_l, 3, 0, 1, 1)
 
-        self.z_min_dsb = QDoubleSpinBox(self.tabWidgetPage2)
+        self.z_min_dsb = QDoubleSpinBox(self.probe_terminal_tab)
         self.z_min_dsb.setObjectName(u"z_min_dsb")
         sizePolicy9.setHeightForWidth(self.z_min_dsb.sizePolicy().hasHeightForWidth())
         self.z_min_dsb.setSizePolicy(sizePolicy9)
@@ -2177,7 +2177,7 @@ class Ui_MainWindow(object):
 
         self.stepsGridLayout.addWidget(self.z_min_dsb, 3, 1, 1, 1)
 
-        self.z_max_dsb = QDoubleSpinBox(self.tabWidgetPage2)
+        self.z_max_dsb = QDoubleSpinBox(self.probe_terminal_tab)
         self.z_max_dsb.setObjectName(u"z_max_dsb")
         sizePolicy9.setHeightForWidth(self.z_max_dsb.sizePolicy().hasHeightForWidth())
         self.z_max_dsb.setSizePolicy(sizePolicy9)
@@ -2193,14 +2193,14 @@ class Ui_MainWindow(object):
 
         self.verticalLayout_17.addLayout(self.stepsGridLayout)
 
-        self.line_4 = QFrame(self.tabWidgetPage2)
+        self.line_4 = QFrame(self.probe_terminal_tab)
         self.line_4.setObjectName(u"line_4")
         self.line_4.setFrameShape(QFrame.Shape.HLine)
         self.line_4.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.verticalLayout_17.addWidget(self.line_4)
 
-        self.serial_te = QTextEdit(self.tabWidgetPage2)
+        self.serial_te = QTextEdit(self.probe_terminal_tab)
         self.serial_te.setObjectName(u"serial_te")
         self.serial_te.setEnabled(True)
         sizePolicy11 = QSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.MinimumExpanding)
@@ -2217,7 +2217,7 @@ class Ui_MainWindow(object):
 
         self.horizontalLayout_2 = QHBoxLayout()
         self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
-        self.send_cb = ComboBoxFilterEnter(self.tabWidgetPage2)
+        self.send_cb = ComboBoxFilterEnter(self.probe_terminal_tab)
         self.send_cb.setObjectName(u"send_cb")
         sizePolicy2.setHeightForWidth(self.send_cb.sizePolicy().hasHeightForWidth())
         self.send_cb.setSizePolicy(sizePolicy2)
@@ -2226,7 +2226,7 @@ class Ui_MainWindow(object):
 
         self.horizontalLayout_2.addWidget(self.send_cb)
 
-        self.send_pb = QPushButton(self.tabWidgetPage2)
+        self.send_pb = QPushButton(self.probe_terminal_tab)
         self.send_pb.setObjectName(u"send_pb")
         sizePolicy12 = QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
         sizePolicy12.setHorizontalStretch(0)
@@ -2247,21 +2247,21 @@ class Ui_MainWindow(object):
         self.horizontalLayout = QHBoxLayout()
         self.horizontalLayout.setSpacing(6)
         self.horizontalLayout.setObjectName(u"horizontalLayout")
-        self.serial_ports_cb = QComboBox(self.tabWidgetPage2)
+        self.serial_ports_cb = QComboBox(self.probe_terminal_tab)
         self.serial_ports_cb.setObjectName(u"serial_ports_cb")
         sizePolicy2.setHeightForWidth(self.serial_ports_cb.sizePolicy().hasHeightForWidth())
         self.serial_ports_cb.setSizePolicy(sizePolicy2)
 
         self.horizontalLayout.addWidget(self.serial_ports_cb)
 
-        self.serial_baud_cb = QComboBox(self.tabWidgetPage2)
+        self.serial_baud_cb = QComboBox(self.probe_terminal_tab)
         self.serial_baud_cb.setObjectName(u"serial_baud_cb")
         sizePolicy2.setHeightForWidth(self.serial_baud_cb.sizePolicy().hasHeightForWidth())
         self.serial_baud_cb.setSizePolicy(sizePolicy2)
 
         self.horizontalLayout.addWidget(self.serial_baud_cb)
 
-        self.refresh_pb = QPushButton(self.tabWidgetPage2)
+        self.refresh_pb = QPushButton(self.probe_terminal_tab)
         self.refresh_pb.setObjectName(u"refresh_pb")
         sizePolicy2.setHeightForWidth(self.refresh_pb.sizePolicy().hasHeightForWidth())
         self.refresh_pb.setSizePolicy(sizePolicy2)
@@ -2278,7 +2278,7 @@ class Ui_MainWindow(object):
 
         self.horizontalLayout_9 = QHBoxLayout()
         self.horizontalLayout_9.setObjectName(u"horizontalLayout_9")
-        self.clear_terminal_pb = QPushButton(self.tabWidgetPage2)
+        self.clear_terminal_pb = QPushButton(self.probe_terminal_tab)
         self.clear_terminal_pb.setObjectName(u"clear_terminal_pb")
         self.clear_terminal_pb.setEnabled(True)
         sizePolicy13 = QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Minimum)
@@ -2294,7 +2294,7 @@ class Ui_MainWindow(object):
 
         self.horizontalLayout_9.addItem(self.horizontalSpacer_2)
 
-        self.connect_pb = QPushButton(self.tabWidgetPage2)
+        self.connect_pb = QPushButton(self.probe_terminal_tab)
         self.connect_pb.setObjectName(u"connect_pb")
         sizePolicy3.setHeightForWidth(self.connect_pb.sizePolicy().hasHeightForWidth())
         self.connect_pb.setSizePolicy(sizePolicy3)
@@ -2305,9 +2305,9 @@ class Ui_MainWindow(object):
 
         self.verticalLayout_17.addLayout(self.horizontalLayout_9)
 
-        self.tabWidget.addTab(self.tabWidgetPage2, "")
+        self.jog_probe_tab_widget.addTab(self.probe_terminal_tab, "")
 
-        self.terminalVerticalLayout.addWidget(self.tabWidget)
+        self.terminalVerticalLayout.addWidget(self.jog_probe_tab_widget)
 
 
         self.controlsVerticalLayout.addLayout(self.terminalVerticalLayout)
@@ -4431,7 +4431,7 @@ class Ui_MainWindow(object):
         self.prepare_widget.setCurrentIndex(1)
         self.jobs_sw.setCurrentIndex(0)
         self.ctrl_tab_widget.setCurrentIndex(1)
-        self.tabWidget.setCurrentIndex(1)
+        self.jog_probe_tab_widget.setCurrentIndex(1)
         self.z_step_cb.setCurrentIndex(3)
         self.xy_step_cb.setCurrentIndex(3)
         self.z_step_cb_2.setCurrentIndex(3)
@@ -4655,7 +4655,7 @@ class Ui_MainWindow(object):
         self.xy_div_10_pb.setText(QCoreApplication.translate("MainWindow", u"\u00f710", None))
         self.xy_mul_10_pb.setText(QCoreApplication.translate("MainWindow", u"x10", None))
         self.xy_minus_1_pb.setText(QCoreApplication.translate("MainWindow", u"-1.0", None))
-        self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab), QCoreApplication.translate("MainWindow", u"Jog", None))
+        self.jog_probe_tab_widget.setTabText(self.jog_probe_tab_widget.indexOf(self.jog_tab), QCoreApplication.translate("MainWindow", u"Jog", None))
         self.probe_pb.setText(QCoreApplication.translate("MainWindow", u"PROBE", None))
         self.get_bbox_pb.setText(QCoreApplication.translate("MainWindow", u"GET BBOX", None))
         self.ABL_pb.setText(QCoreApplication.translate("MainWindow", u"ABL", None))
@@ -4693,7 +4693,7 @@ class Ui_MainWindow(object):
         self.connect_pb.setStatusTip(QCoreApplication.translate("MainWindow", u"Connect to selected serial port.", None))
 #endif // QT_CONFIG(statustip)
         self.connect_pb.setText(QCoreApplication.translate("MainWindow", u"Connect", None))
-        self.tabWidget.setTabText(self.tabWidget.indexOf(self.tabWidgetPage2), QCoreApplication.translate("MainWindow", u"Probe/Terminal", None))
+        self.jog_probe_tab_widget.setTabText(self.jog_probe_tab_widget.indexOf(self.probe_terminal_tab), QCoreApplication.translate("MainWindow", u"Probe/Terminal", None))
         self.ctrl_tab_widget.setTabText(self.ctrl_tab_widget.indexOf(self.sender_tab), QCoreApplication.translate("MainWindow", u"Sender", None))
 #if QT_CONFIG(tooltip)
         self.probe_led_la.setToolTip(QCoreApplication.translate("MainWindow", u"Probe in idle", None))

--- a/src/TheAntFarm/ui_the_ant_farm.py
+++ b/src/TheAntFarm/ui_the_ant_farm.py
@@ -1301,13 +1301,6 @@ class Ui_MainWindow(object):
         self.controlsVerticalLayout = QVBoxLayout()
         self.controlsVerticalLayout.setObjectName(u"controlsVerticalLayout")
         self.controlsVerticalLayout.setSizeConstraint(QLayout.SizeConstraint.SetDefaultConstraint)
-        self.line_4 = QFrame(self.sender_tab)
-        self.line_4.setObjectName(u"line_4")
-        self.line_4.setFrameShape(QFrame.Shape.HLine)
-        self.line_4.setFrameShadow(QFrame.Shadow.Sunken)
-
-        self.controlsVerticalLayout.addWidget(self.line_4)
-
         self.droGridLayout = QGridLayout()
         self.droGridLayout.setObjectName(u"droGridLayout")
         self.droGridLayout.setHorizontalSpacing(0)
@@ -1521,278 +1514,6 @@ class Ui_MainWindow(object):
 
         self.controlsVerticalLayout.addLayout(self.droGridLayout)
 
-        self.line_3 = QFrame(self.sender_tab)
-        self.line_3.setObjectName(u"line_3")
-        self.line_3.setFrameShape(QFrame.Shape.HLine)
-        self.line_3.setFrameShadow(QFrame.Shadow.Sunken)
-
-        self.controlsVerticalLayout.addWidget(self.line_3)
-
-        self.probeABLGridLayout = QGridLayout()
-        self.probeABLGridLayout.setObjectName(u"probeABLGridLayout")
-        self.probeABLGridLayout.setContentsMargins(0, 0, 0, 0)
-        self.probe_pb = QPushButton(self.sender_tab)
-        self.probe_pb.setObjectName(u"probe_pb")
-        sizePolicy7.setHeightForWidth(self.probe_pb.sizePolicy().hasHeightForWidth())
-        self.probe_pb.setSizePolicy(sizePolicy7)
-        self.probe_pb.setMinimumSize(QSize(0, 20))
-        self.probe_pb.setMaximumSize(QSize(16777215, 23))
-
-        self.probeABLGridLayout.addWidget(self.probe_pb, 0, 0, 1, 1, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
-
-        self.get_bbox_pb = QPushButton(self.sender_tab)
-        self.get_bbox_pb.setObjectName(u"get_bbox_pb")
-        sizePolicy7.setHeightForWidth(self.get_bbox_pb.sizePolicy().hasHeightForWidth())
-        self.get_bbox_pb.setSizePolicy(sizePolicy7)
-        self.get_bbox_pb.setMinimumSize(QSize(0, 20))
-        self.get_bbox_pb.setMaximumSize(QSize(16777215, 23))
-        self.get_bbox_pb.setFont(font)
-
-        self.probeABLGridLayout.addWidget(self.get_bbox_pb, 0, 2, 1, 1, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
-
-        self.horizontalLayout_11 = QHBoxLayout()
-        self.horizontalLayout_11.setObjectName(u"horizontalLayout_11")
-        self.ABL_pb = QPushButton(self.sender_tab)
-        self.ABL_pb.setObjectName(u"ABL_pb")
-        sizePolicy7.setHeightForWidth(self.ABL_pb.sizePolicy().hasHeightForWidth())
-        self.ABL_pb.setSizePolicy(sizePolicy7)
-        self.ABL_pb.setMinimumSize(QSize(0, 20))
-        self.ABL_pb.setMaximumSize(QSize(16777215, 23))
-        self.ABL_pb.setFont(font)
-
-        self.horizontalLayout_11.addWidget(self.ABL_pb)
-
-        self.abl_active_chb = QCheckBox(self.sender_tab)
-        self.abl_active_chb.setObjectName(u"abl_active_chb")
-        sizePolicy8 = QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.MinimumExpanding)
-        sizePolicy8.setHorizontalStretch(0)
-        sizePolicy8.setVerticalStretch(0)
-        sizePolicy8.setHeightForWidth(self.abl_active_chb.sizePolicy().hasHeightForWidth())
-        self.abl_active_chb.setSizePolicy(sizePolicy8)
-        self.abl_active_chb.setMinimumSize(QSize(0, 20))
-        self.abl_active_chb.setMaximumSize(QSize(16777215, 23))
-        self.abl_active_chb.setChecked(True)
-
-        self.horizontalLayout_11.addWidget(self.abl_active_chb)
-
-
-        self.probeABLGridLayout.addLayout(self.horizontalLayout_11, 0, 1, 1, 1)
-
-
-        self.controlsVerticalLayout.addLayout(self.probeABLGridLayout)
-
-        self.stepsGridLayout = QGridLayout()
-        self.stepsGridLayout.setObjectName(u"stepsGridLayout")
-        self.stepsGridLayout.setVerticalSpacing(0)
-        self.min_l = QLabel(self.sender_tab)
-        self.min_l.setObjectName(u"min_l")
-        sizePolicy9 = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.MinimumExpanding)
-        sizePolicy9.setHorizontalStretch(0)
-        sizePolicy9.setVerticalStretch(0)
-        sizePolicy9.setHeightForWidth(self.min_l.sizePolicy().hasHeightForWidth())
-        self.min_l.setSizePolicy(sizePolicy9)
-        self.min_l.setMinimumSize(QSize(0, 20))
-        self.min_l.setMaximumSize(QSize(16777215, 23))
-        self.min_l.setFont(font)
-        self.min_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
-        self.stepsGridLayout.addWidget(self.min_l, 0, 1, 1, 1)
-
-        self.max_l = QLabel(self.sender_tab)
-        self.max_l.setObjectName(u"max_l")
-        sizePolicy9.setHeightForWidth(self.max_l.sizePolicy().hasHeightForWidth())
-        self.max_l.setSizePolicy(sizePolicy9)
-        self.max_l.setMinimumSize(QSize(0, 20))
-        self.max_l.setMaximumSize(QSize(16777215, 23))
-        self.max_l.setFont(font)
-        self.max_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
-        self.stepsGridLayout.addWidget(self.max_l, 0, 2, 1, 1)
-
-        self.step_l = QLabel(self.sender_tab)
-        self.step_l.setObjectName(u"step_l")
-        sizePolicy9.setHeightForWidth(self.step_l.sizePolicy().hasHeightForWidth())
-        self.step_l.setSizePolicy(sizePolicy9)
-        self.step_l.setMinimumSize(QSize(0, 20))
-        self.step_l.setMaximumSize(QSize(16777215, 23))
-        self.step_l.setFont(font)
-        self.step_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
-        self.stepsGridLayout.addWidget(self.step_l, 0, 3, 1, 1)
-
-        self.n_step_l = QLabel(self.sender_tab)
-        self.n_step_l.setObjectName(u"n_step_l")
-        sizePolicy9.setHeightForWidth(self.n_step_l.sizePolicy().hasHeightForWidth())
-        self.n_step_l.setSizePolicy(sizePolicy9)
-        self.n_step_l.setMinimumSize(QSize(0, 20))
-        self.n_step_l.setMaximumSize(QSize(16777215, 23))
-        self.n_step_l.setFont(font)
-        self.n_step_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
-        self.stepsGridLayout.addWidget(self.n_step_l, 0, 4, 1, 1)
-
-        self.x_l = QLabel(self.sender_tab)
-        self.x_l.setObjectName(u"x_l")
-        sizePolicy9.setHeightForWidth(self.x_l.sizePolicy().hasHeightForWidth())
-        self.x_l.setSizePolicy(sizePolicy9)
-        self.x_l.setMinimumSize(QSize(0, 20))
-        self.x_l.setMaximumSize(QSize(16777215, 23))
-        self.x_l.setFont(font)
-        self.x_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
-        self.stepsGridLayout.addWidget(self.x_l, 1, 0, 1, 1)
-
-        self.x_min_dsb = QDoubleSpinBox(self.sender_tab)
-        self.x_min_dsb.setObjectName(u"x_min_dsb")
-        sizePolicy8.setHeightForWidth(self.x_min_dsb.sizePolicy().hasHeightForWidth())
-        self.x_min_dsb.setSizePolicy(sizePolicy8)
-        self.x_min_dsb.setMinimumSize(QSize(0, 20))
-        self.x_min_dsb.setMaximumSize(QSize(16777215, 23))
-        self.x_min_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.x_min_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
-        self.x_min_dsb.setMinimum(-1000.000000000000000)
-        self.x_min_dsb.setMaximum(1000.000000000000000)
-
-        self.stepsGridLayout.addWidget(self.x_min_dsb, 1, 1, 1, 1)
-
-        self.x_max_dsb = QDoubleSpinBox(self.sender_tab)
-        self.x_max_dsb.setObjectName(u"x_max_dsb")
-        sizePolicy8.setHeightForWidth(self.x_max_dsb.sizePolicy().hasHeightForWidth())
-        self.x_max_dsb.setSizePolicy(sizePolicy8)
-        self.x_max_dsb.setMinimumSize(QSize(0, 20))
-        self.x_max_dsb.setMaximumSize(QSize(16777215, 23))
-        self.x_max_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.x_max_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
-        self.x_max_dsb.setMinimum(-1000.000000000000000)
-        self.x_max_dsb.setMaximum(1000.000000000000000)
-
-        self.stepsGridLayout.addWidget(self.x_max_dsb, 1, 2, 1, 1)
-
-        self.x_step_dsb = QDoubleSpinBox(self.sender_tab)
-        self.x_step_dsb.setObjectName(u"x_step_dsb")
-        self.x_step_dsb.setEnabled(False)
-        sizePolicy8.setHeightForWidth(self.x_step_dsb.sizePolicy().hasHeightForWidth())
-        self.x_step_dsb.setSizePolicy(sizePolicy8)
-        self.x_step_dsb.setMinimumSize(QSize(0, 20))
-        self.x_step_dsb.setMaximumSize(QSize(16777215, 23))
-        self.x_step_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.x_step_dsb.setReadOnly(True)
-        self.x_step_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
-
-        self.stepsGridLayout.addWidget(self.x_step_dsb, 1, 3, 1, 1)
-
-        self.x_num_step_sb = QSpinBox(self.sender_tab)
-        self.x_num_step_sb.setObjectName(u"x_num_step_sb")
-        sizePolicy8.setHeightForWidth(self.x_num_step_sb.sizePolicy().hasHeightForWidth())
-        self.x_num_step_sb.setSizePolicy(sizePolicy8)
-        self.x_num_step_sb.setMinimumSize(QSize(0, 20))
-        self.x_num_step_sb.setMaximumSize(QSize(16777215, 23))
-        self.x_num_step_sb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.x_num_step_sb.setMinimum(1)
-
-        self.stepsGridLayout.addWidget(self.x_num_step_sb, 1, 4, 1, 1)
-
-        self.y_l = QLabel(self.sender_tab)
-        self.y_l.setObjectName(u"y_l")
-        sizePolicy9.setHeightForWidth(self.y_l.sizePolicy().hasHeightForWidth())
-        self.y_l.setSizePolicy(sizePolicy9)
-        self.y_l.setMinimumSize(QSize(0, 20))
-        self.y_l.setMaximumSize(QSize(16777215, 23))
-        self.y_l.setFont(font)
-        self.y_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
-        self.stepsGridLayout.addWidget(self.y_l, 2, 0, 1, 1)
-
-        self.y_min_dsb = QDoubleSpinBox(self.sender_tab)
-        self.y_min_dsb.setObjectName(u"y_min_dsb")
-        sizePolicy8.setHeightForWidth(self.y_min_dsb.sizePolicy().hasHeightForWidth())
-        self.y_min_dsb.setSizePolicy(sizePolicy8)
-        self.y_min_dsb.setMinimumSize(QSize(0, 20))
-        self.y_min_dsb.setMaximumSize(QSize(16777215, 23))
-        self.y_min_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.y_min_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
-        self.y_min_dsb.setMinimum(-1000.000000000000000)
-        self.y_min_dsb.setMaximum(1000.000000000000000)
-
-        self.stepsGridLayout.addWidget(self.y_min_dsb, 2, 1, 1, 1)
-
-        self.y_max_dsb = QDoubleSpinBox(self.sender_tab)
-        self.y_max_dsb.setObjectName(u"y_max_dsb")
-        sizePolicy8.setHeightForWidth(self.y_max_dsb.sizePolicy().hasHeightForWidth())
-        self.y_max_dsb.setSizePolicy(sizePolicy8)
-        self.y_max_dsb.setMinimumSize(QSize(0, 20))
-        self.y_max_dsb.setMaximumSize(QSize(16777215, 23))
-        self.y_max_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.y_max_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
-        self.y_max_dsb.setMinimum(-1000.000000000000000)
-        self.y_max_dsb.setMaximum(1000.000000000000000)
-
-        self.stepsGridLayout.addWidget(self.y_max_dsb, 2, 2, 1, 1)
-
-        self.y_step_dsb = QDoubleSpinBox(self.sender_tab)
-        self.y_step_dsb.setObjectName(u"y_step_dsb")
-        self.y_step_dsb.setEnabled(False)
-        sizePolicy8.setHeightForWidth(self.y_step_dsb.sizePolicy().hasHeightForWidth())
-        self.y_step_dsb.setSizePolicy(sizePolicy8)
-        self.y_step_dsb.setMinimumSize(QSize(0, 20))
-        self.y_step_dsb.setMaximumSize(QSize(16777215, 23))
-        self.y_step_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.y_step_dsb.setReadOnly(True)
-        self.y_step_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
-
-        self.stepsGridLayout.addWidget(self.y_step_dsb, 2, 3, 1, 1)
-
-        self.y_num_step_sb = QSpinBox(self.sender_tab)
-        self.y_num_step_sb.setObjectName(u"y_num_step_sb")
-        sizePolicy8.setHeightForWidth(self.y_num_step_sb.sizePolicy().hasHeightForWidth())
-        self.y_num_step_sb.setSizePolicy(sizePolicy8)
-        self.y_num_step_sb.setMinimumSize(QSize(0, 20))
-        self.y_num_step_sb.setMaximumSize(QSize(16777215, 23))
-        self.y_num_step_sb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.y_num_step_sb.setMinimum(1)
-
-        self.stepsGridLayout.addWidget(self.y_num_step_sb, 2, 4, 1, 1)
-
-        self.z_l = QLabel(self.sender_tab)
-        self.z_l.setObjectName(u"z_l")
-        sizePolicy9.setHeightForWidth(self.z_l.sizePolicy().hasHeightForWidth())
-        self.z_l.setSizePolicy(sizePolicy9)
-        self.z_l.setMinimumSize(QSize(0, 20))
-        self.z_l.setMaximumSize(QSize(16777215, 23))
-        self.z_l.setFont(font)
-        self.z_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
-        self.stepsGridLayout.addWidget(self.z_l, 3, 0, 1, 1)
-
-        self.z_min_dsb = QDoubleSpinBox(self.sender_tab)
-        self.z_min_dsb.setObjectName(u"z_min_dsb")
-        sizePolicy8.setHeightForWidth(self.z_min_dsb.sizePolicy().hasHeightForWidth())
-        self.z_min_dsb.setSizePolicy(sizePolicy8)
-        self.z_min_dsb.setMinimumSize(QSize(0, 20))
-        self.z_min_dsb.setMaximumSize(QSize(16777215, 23))
-        self.z_min_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.z_min_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
-        self.z_min_dsb.setMinimum(-1000.000000000000000)
-        self.z_min_dsb.setMaximum(1000.000000000000000)
-
-        self.stepsGridLayout.addWidget(self.z_min_dsb, 3, 1, 1, 1)
-
-        self.z_max_dsb = QDoubleSpinBox(self.sender_tab)
-        self.z_max_dsb.setObjectName(u"z_max_dsb")
-        sizePolicy8.setHeightForWidth(self.z_max_dsb.sizePolicy().hasHeightForWidth())
-        self.z_max_dsb.setSizePolicy(sizePolicy8)
-        self.z_max_dsb.setMinimumSize(QSize(0, 20))
-        self.z_max_dsb.setMaximumSize(QSize(16777215, 23))
-        self.z_max_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.z_max_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
-        self.z_max_dsb.setMinimum(-1000.000000000000000)
-        self.z_max_dsb.setMaximum(1000.000000000000000)
-
-        self.stepsGridLayout.addWidget(self.z_max_dsb, 3, 2, 1, 1)
-
-
-        self.controlsVerticalLayout.addLayout(self.stepsGridLayout)
-
         self.line = QFrame(self.sender_tab)
         self.line.setObjectName(u"line")
         self.line.setFrameShape(QFrame.Shape.HLine)
@@ -1800,12 +1521,31 @@ class Ui_MainWindow(object):
 
         self.controlsVerticalLayout.addWidget(self.line)
 
+        self.terminalVerticalLayout = QVBoxLayout()
+        self.terminalVerticalLayout.setObjectName(u"terminalVerticalLayout")
+        self.tabWidget = QTabWidget(self.sender_tab)
+        self.tabWidget.setObjectName(u"tabWidget")
+        sizePolicy8 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        sizePolicy8.setHorizontalStretch(0)
+        sizePolicy8.setVerticalStretch(0)
+        sizePolicy8.setHeightForWidth(self.tabWidget.sizePolicy().hasHeightForWidth())
+        self.tabWidget.setSizePolicy(sizePolicy8)
+        self.tabWidget.setMinimumSize(QSize(0, 0))
+        self.tabWidget.setTabPosition(QTabWidget.TabPosition.South)
+        self.tabWidget.setTabBarAutoHide(True)
+        self.tab = QWidget()
+        self.tab.setObjectName(u"tab")
+        self.tab.setEnabled(True)
+        self.horizontalLayout_19 = QHBoxLayout(self.tab)
+        self.horizontalLayout_19.setObjectName(u"horizontalLayout_19")
+        self.verticalLayout_18 = QVBoxLayout()
+        self.verticalLayout_18.setObjectName(u"verticalLayout_18")
         self.jogGridlayout = QGridLayout()
         self.jogGridlayout.setObjectName(u"jogGridlayout")
         self.zMoveGridLayout = QGridLayout()
         self.zMoveGridLayout.setObjectName(u"zMoveGridLayout")
         self.zMoveGridLayout.setSizeConstraint(QLayout.SizeConstraint.SetDefaultConstraint)
-        self.z_plus_pb = QPushButton(self.sender_tab)
+        self.z_plus_pb = QPushButton(self.tab)
         self.z_plus_pb.setObjectName(u"z_plus_pb")
         sizePolicy3.setHeightForWidth(self.z_plus_pb.sizePolicy().hasHeightForWidth())
         self.z_plus_pb.setSizePolicy(sizePolicy3)
@@ -1817,7 +1557,7 @@ class Ui_MainWindow(object):
 
         self.zMoveGridLayout.addWidget(self.z_plus_pb, 0, 0, 1, 1)
 
-        self.z_minus_pb = QPushButton(self.sender_tab)
+        self.z_minus_pb = QPushButton(self.tab)
         self.z_minus_pb.setObjectName(u"z_minus_pb")
         sizePolicy3.setHeightForWidth(self.z_minus_pb.sizePolicy().hasHeightForWidth())
         self.z_minus_pb.setSizePolicy(sizePolicy3)
@@ -1835,7 +1575,7 @@ class Ui_MainWindow(object):
         self.xyMoveGridLayout = QGridLayout()
         self.xyMoveGridLayout.setObjectName(u"xyMoveGridLayout")
         self.xyMoveGridLayout.setContentsMargins(0, 0, 0, 0)
-        self.x_minus_y_plus_pb = QToolButton(self.sender_tab)
+        self.x_minus_y_plus_pb = QToolButton(self.tab)
         self.x_minus_y_plus_pb.setObjectName(u"x_minus_y_plus_pb")
         sizePolicy3.setHeightForWidth(self.x_minus_y_plus_pb.sizePolicy().hasHeightForWidth())
         self.x_minus_y_plus_pb.setSizePolicy(sizePolicy3)
@@ -1847,7 +1587,7 @@ class Ui_MainWindow(object):
 
         self.xyMoveGridLayout.addWidget(self.x_minus_y_plus_pb, 0, 0, 1, 1)
 
-        self.x_plus_y_minus_pb = QToolButton(self.sender_tab)
+        self.x_plus_y_minus_pb = QToolButton(self.tab)
         self.x_plus_y_minus_pb.setObjectName(u"x_plus_y_minus_pb")
         sizePolicy3.setHeightForWidth(self.x_plus_y_minus_pb.sizePolicy().hasHeightForWidth())
         self.x_plus_y_minus_pb.setSizePolicy(sizePolicy3)
@@ -1859,7 +1599,7 @@ class Ui_MainWindow(object):
 
         self.xyMoveGridLayout.addWidget(self.x_plus_y_minus_pb, 2, 2, 1, 1)
 
-        self.x_minus_pb = QToolButton(self.sender_tab)
+        self.x_minus_pb = QToolButton(self.tab)
         self.x_minus_pb.setObjectName(u"x_minus_pb")
         sizePolicy3.setHeightForWidth(self.x_minus_pb.sizePolicy().hasHeightForWidth())
         self.x_minus_pb.setSizePolicy(sizePolicy3)
@@ -1871,7 +1611,7 @@ class Ui_MainWindow(object):
 
         self.xyMoveGridLayout.addWidget(self.x_minus_pb, 1, 0, 1, 1)
 
-        self.x_minus_y_minus_pb = QToolButton(self.sender_tab)
+        self.x_minus_y_minus_pb = QToolButton(self.tab)
         self.x_minus_y_minus_pb.setObjectName(u"x_minus_y_minus_pb")
         sizePolicy3.setHeightForWidth(self.x_minus_y_minus_pb.sizePolicy().hasHeightForWidth())
         self.x_minus_y_minus_pb.setSizePolicy(sizePolicy3)
@@ -1883,7 +1623,7 @@ class Ui_MainWindow(object):
 
         self.xyMoveGridLayout.addWidget(self.x_minus_y_minus_pb, 2, 0, 1, 1)
 
-        self.y_plus_pb = QToolButton(self.sender_tab)
+        self.y_plus_pb = QToolButton(self.tab)
         self.y_plus_pb.setObjectName(u"y_plus_pb")
         sizePolicy3.setHeightForWidth(self.y_plus_pb.sizePolicy().hasHeightForWidth())
         self.y_plus_pb.setSizePolicy(sizePolicy3)
@@ -1893,7 +1633,7 @@ class Ui_MainWindow(object):
 
         self.xyMoveGridLayout.addWidget(self.y_plus_pb, 0, 1, 1, 1)
 
-        self.center_tb = QToolButton(self.sender_tab)
+        self.center_tb = QToolButton(self.tab)
         self.center_tb.setObjectName(u"center_tb")
         sizePolicy3.setHeightForWidth(self.center_tb.sizePolicy().hasHeightForWidth())
         self.center_tb.setSizePolicy(sizePolicy3)
@@ -1905,7 +1645,7 @@ class Ui_MainWindow(object):
 
         self.xyMoveGridLayout.addWidget(self.center_tb, 1, 1, 1, 1)
 
-        self.y_minus_pb = QToolButton(self.sender_tab)
+        self.y_minus_pb = QToolButton(self.tab)
         self.y_minus_pb.setObjectName(u"y_minus_pb")
         sizePolicy3.setHeightForWidth(self.y_minus_pb.sizePolicy().hasHeightForWidth())
         self.y_minus_pb.setSizePolicy(sizePolicy3)
@@ -1915,7 +1655,7 @@ class Ui_MainWindow(object):
 
         self.xyMoveGridLayout.addWidget(self.y_minus_pb, 2, 1, 1, 1)
 
-        self.x_plus_y_plus_pb = QToolButton(self.sender_tab)
+        self.x_plus_y_plus_pb = QToolButton(self.tab)
         self.x_plus_y_plus_pb.setObjectName(u"x_plus_y_plus_pb")
         sizePolicy3.setHeightForWidth(self.x_plus_y_plus_pb.sizePolicy().hasHeightForWidth())
         self.x_plus_y_plus_pb.setSizePolicy(sizePolicy3)
@@ -1927,7 +1667,7 @@ class Ui_MainWindow(object):
 
         self.xyMoveGridLayout.addWidget(self.x_plus_y_plus_pb, 0, 2, 1, 1)
 
-        self.x_plus_pb = QToolButton(self.sender_tab)
+        self.x_plus_pb = QToolButton(self.tab)
         self.x_plus_pb.setObjectName(u"x_plus_pb")
         sizePolicy3.setHeightForWidth(self.x_plus_pb.sizePolicy().hasHeightForWidth())
         self.x_plus_pb.setSizePolicy(sizePolicy3)
@@ -1947,7 +1687,7 @@ class Ui_MainWindow(object):
         self.horizontalLayout_14 = QHBoxLayout()
         self.horizontalLayout_14.setObjectName(u"horizontalLayout_14")
         self.horizontalLayout_14.setSizeConstraint(QLayout.SizeConstraint.SetDefaultConstraint)
-        self.z_jog_l_2 = QLabel(self.sender_tab)
+        self.z_jog_l_2 = QLabel(self.tab)
         self.z_jog_l_2.setObjectName(u"z_jog_l_2")
         sizePolicy3.setHeightForWidth(self.z_jog_l_2.sizePolicy().hasHeightForWidth())
         self.z_jog_l_2.setSizePolicy(sizePolicy3)
@@ -1958,7 +1698,7 @@ class Ui_MainWindow(object):
 
         self.horizontalLayout_14.addWidget(self.z_jog_l_2, 0, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
 
-        self.z_step_cb = QComboBox(self.sender_tab)
+        self.z_step_cb = QComboBox(self.tab)
         self.z_step_cb.addItem("")
         self.z_step_cb.addItem("")
         self.z_step_cb.addItem("")
@@ -1981,7 +1721,7 @@ class Ui_MainWindow(object):
 
         self.gridLayout_18 = QGridLayout()
         self.gridLayout_18.setObjectName(u"gridLayout_18")
-        self.z_step_val_dsb = QDoubleSpinBox(self.sender_tab)
+        self.z_step_val_dsb = QDoubleSpinBox(self.tab)
         self.z_step_val_dsb.setObjectName(u"z_step_val_dsb")
         self.z_step_val_dsb.setMinimumSize(QSize(70, 20))
         self.z_step_val_dsb.setMaximumSize(QSize(70, 16777215))
@@ -1995,7 +1735,7 @@ class Ui_MainWindow(object):
 
         self.gridLayout_18.addWidget(self.z_step_val_dsb, 1, 1, 1, 1)
 
-        self.z_mul_10_pb = QPushButton(self.sender_tab)
+        self.z_mul_10_pb = QPushButton(self.tab)
         self.z_mul_10_pb.setObjectName(u"z_mul_10_pb")
         sizePolicy3.setHeightForWidth(self.z_mul_10_pb.sizePolicy().hasHeightForWidth())
         self.z_mul_10_pb.setSizePolicy(sizePolicy3)
@@ -2009,7 +1749,7 @@ class Ui_MainWindow(object):
 
         self.gridLayout_18.addWidget(self.z_mul_10_pb, 1, 2, 1, 1)
 
-        self.z_div_10_pb = QPushButton(self.sender_tab)
+        self.z_div_10_pb = QPushButton(self.tab)
         self.z_div_10_pb.setObjectName(u"z_div_10_pb")
         sizePolicy3.setHeightForWidth(self.z_div_10_pb.sizePolicy().hasHeightForWidth())
         self.z_div_10_pb.setSizePolicy(sizePolicy3)
@@ -2020,7 +1760,7 @@ class Ui_MainWindow(object):
 
         self.gridLayout_18.addWidget(self.z_div_10_pb, 1, 0, 1, 1)
 
-        self.z_minus_1_pb = QPushButton(self.sender_tab)
+        self.z_minus_1_pb = QPushButton(self.tab)
         self.z_minus_1_pb.setObjectName(u"z_minus_1_pb")
         sizePolicy3.setHeightForWidth(self.z_minus_1_pb.sizePolicy().hasHeightForWidth())
         self.z_minus_1_pb.setSizePolicy(sizePolicy3)
@@ -2031,7 +1771,7 @@ class Ui_MainWindow(object):
 
         self.gridLayout_18.addWidget(self.z_minus_1_pb, 2, 1, 1, 1)
 
-        self.z_plus_1_pb = QPushButton(self.sender_tab)
+        self.z_plus_1_pb = QPushButton(self.tab)
         self.z_plus_1_pb.setObjectName(u"z_plus_1_pb")
         sizePolicy3.setHeightForWidth(self.z_plus_1_pb.sizePolicy().hasHeightForWidth())
         self.z_plus_1_pb.setSizePolicy(sizePolicy3)
@@ -2053,7 +1793,7 @@ class Ui_MainWindow(object):
         self.horizontalLayout_12 = QHBoxLayout()
         self.horizontalLayout_12.setObjectName(u"horizontalLayout_12")
         self.horizontalLayout_12.setSizeConstraint(QLayout.SizeConstraint.SetDefaultConstraint)
-        self.xy_jog_l = QLabel(self.sender_tab)
+        self.xy_jog_l = QLabel(self.tab)
         self.xy_jog_l.setObjectName(u"xy_jog_l")
         sizePolicy3.setHeightForWidth(self.xy_jog_l.sizePolicy().hasHeightForWidth())
         self.xy_jog_l.setSizePolicy(sizePolicy3)
@@ -2063,7 +1803,7 @@ class Ui_MainWindow(object):
 
         self.horizontalLayout_12.addWidget(self.xy_jog_l, 0, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
 
-        self.xy_step_cb = QComboBox(self.sender_tab)
+        self.xy_step_cb = QComboBox(self.tab)
         self.xy_step_cb.addItem("")
         self.xy_step_cb.addItem("")
         self.xy_step_cb.addItem("")
@@ -2085,7 +1825,7 @@ class Ui_MainWindow(object):
 
         self.gridLayout_16 = QGridLayout()
         self.gridLayout_16.setObjectName(u"gridLayout_16")
-        self.xy_plus_1_pb = QPushButton(self.sender_tab)
+        self.xy_plus_1_pb = QPushButton(self.tab)
         self.xy_plus_1_pb.setObjectName(u"xy_plus_1_pb")
         sizePolicy3.setHeightForWidth(self.xy_plus_1_pb.sizePolicy().hasHeightForWidth())
         self.xy_plus_1_pb.setSizePolicy(sizePolicy3)
@@ -2096,7 +1836,7 @@ class Ui_MainWindow(object):
 
         self.gridLayout_16.addWidget(self.xy_plus_1_pb, 0, 1, 1, 1)
 
-        self.xy_div_10_pb = QPushButton(self.sender_tab)
+        self.xy_div_10_pb = QPushButton(self.tab)
         self.xy_div_10_pb.setObjectName(u"xy_div_10_pb")
         sizePolicy3.setHeightForWidth(self.xy_div_10_pb.sizePolicy().hasHeightForWidth())
         self.xy_div_10_pb.setSizePolicy(sizePolicy3)
@@ -2107,7 +1847,7 @@ class Ui_MainWindow(object):
 
         self.gridLayout_16.addWidget(self.xy_div_10_pb, 1, 0, 1, 1)
 
-        self.xy_step_val_dsb = QDoubleSpinBox(self.sender_tab)
+        self.xy_step_val_dsb = QDoubleSpinBox(self.tab)
         self.xy_step_val_dsb.setObjectName(u"xy_step_val_dsb")
         sizePolicy3.setHeightForWidth(self.xy_step_val_dsb.sizePolicy().hasHeightForWidth())
         self.xy_step_val_dsb.setSizePolicy(sizePolicy3)
@@ -2123,7 +1863,7 @@ class Ui_MainWindow(object):
 
         self.gridLayout_16.addWidget(self.xy_step_val_dsb, 1, 1, 1, 1)
 
-        self.xy_mul_10_pb = QPushButton(self.sender_tab)
+        self.xy_mul_10_pb = QPushButton(self.tab)
         self.xy_mul_10_pb.setObjectName(u"xy_mul_10_pb")
         sizePolicy3.setHeightForWidth(self.xy_mul_10_pb.sizePolicy().hasHeightForWidth())
         self.xy_mul_10_pb.setSizePolicy(sizePolicy3)
@@ -2134,7 +1874,7 @@ class Ui_MainWindow(object):
 
         self.gridLayout_16.addWidget(self.xy_mul_10_pb, 1, 2, 1, 1)
 
-        self.xy_minus_1_pb = QPushButton(self.sender_tab)
+        self.xy_minus_1_pb = QPushButton(self.tab)
         self.xy_minus_1_pb.setObjectName(u"xy_minus_1_pb")
         sizePolicy3.setHeightForWidth(self.xy_minus_1_pb.sizePolicy().hasHeightForWidth())
         self.xy_minus_1_pb.setSizePolicy(sizePolicy3)
@@ -2151,7 +1891,7 @@ class Ui_MainWindow(object):
 
         self.jogGridlayout.addLayout(self.xyStepAdjustmentVerticalLayout, 0, 1, 1, 1)
 
-        self.line_2 = QFrame(self.sender_tab)
+        self.line_2 = QFrame(self.tab)
         self.line_2.setObjectName(u"line_2")
         self.line_2.setLineWidth(1)
         self.line_2.setFrameShape(QFrame.Shape.HLine)
@@ -2159,7 +1899,7 @@ class Ui_MainWindow(object):
 
         self.jogGridlayout.addWidget(self.line_2, 1, 1, 1, 1)
 
-        self.line_5 = QFrame(self.sender_tab)
+        self.line_5 = QFrame(self.tab)
         self.line_5.setObjectName(u"line_5")
         self.line_5.setFrameShape(QFrame.Shape.HLine)
         self.line_5.setFrameShadow(QFrame.Shadow.Sunken)
@@ -2167,28 +1907,317 @@ class Ui_MainWindow(object):
         self.jogGridlayout.addWidget(self.line_5, 1, 0, 1, 1)
 
 
-        self.controlsVerticalLayout.addLayout(self.jogGridlayout)
+        self.verticalLayout_18.addLayout(self.jogGridlayout)
 
-        self.terminalVerticalLayout = QVBoxLayout()
-        self.terminalVerticalLayout.setObjectName(u"terminalVerticalLayout")
-        self.serial_te = QTextEdit(self.sender_tab)
-        self.serial_te.setObjectName(u"serial_te")
-        self.serial_te.setEnabled(True)
-        sizePolicy10 = QSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.MinimumExpanding)
+        self.verticalSpacer_7 = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+
+        self.verticalLayout_18.addItem(self.verticalSpacer_7)
+
+
+        self.horizontalLayout_19.addLayout(self.verticalLayout_18)
+
+        self.tabWidget.addTab(self.tab, "")
+        self.tabWidgetPage2 = QWidget()
+        self.tabWidgetPage2.setObjectName(u"tabWidgetPage2")
+        self.verticalLayout_17 = QVBoxLayout(self.tabWidgetPage2)
+        self.verticalLayout_17.setObjectName(u"verticalLayout_17")
+        self.probeABLGridLayout = QGridLayout()
+        self.probeABLGridLayout.setObjectName(u"probeABLGridLayout")
+        self.probeABLGridLayout.setContentsMargins(0, 0, 0, 0)
+        self.probe_pb = QPushButton(self.tabWidgetPage2)
+        self.probe_pb.setObjectName(u"probe_pb")
+        sizePolicy7.setHeightForWidth(self.probe_pb.sizePolicy().hasHeightForWidth())
+        self.probe_pb.setSizePolicy(sizePolicy7)
+        self.probe_pb.setMinimumSize(QSize(0, 20))
+        self.probe_pb.setMaximumSize(QSize(16777215, 23))
+
+        self.probeABLGridLayout.addWidget(self.probe_pb, 0, 0, 1, 1, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+
+        self.get_bbox_pb = QPushButton(self.tabWidgetPage2)
+        self.get_bbox_pb.setObjectName(u"get_bbox_pb")
+        sizePolicy7.setHeightForWidth(self.get_bbox_pb.sizePolicy().hasHeightForWidth())
+        self.get_bbox_pb.setSizePolicy(sizePolicy7)
+        self.get_bbox_pb.setMinimumSize(QSize(0, 20))
+        self.get_bbox_pb.setMaximumSize(QSize(16777215, 23))
+        self.get_bbox_pb.setFont(font)
+
+        self.probeABLGridLayout.addWidget(self.get_bbox_pb, 0, 2, 1, 1, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+
+        self.horizontalLayout_11 = QHBoxLayout()
+        self.horizontalLayout_11.setObjectName(u"horizontalLayout_11")
+        self.ABL_pb = QPushButton(self.tabWidgetPage2)
+        self.ABL_pb.setObjectName(u"ABL_pb")
+        sizePolicy7.setHeightForWidth(self.ABL_pb.sizePolicy().hasHeightForWidth())
+        self.ABL_pb.setSizePolicy(sizePolicy7)
+        self.ABL_pb.setMinimumSize(QSize(0, 20))
+        self.ABL_pb.setMaximumSize(QSize(16777215, 23))
+        self.ABL_pb.setFont(font)
+
+        self.horizontalLayout_11.addWidget(self.ABL_pb)
+
+        self.abl_active_chb = QCheckBox(self.tabWidgetPage2)
+        self.abl_active_chb.setObjectName(u"abl_active_chb")
+        sizePolicy9 = QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.MinimumExpanding)
+        sizePolicy9.setHorizontalStretch(0)
+        sizePolicy9.setVerticalStretch(0)
+        sizePolicy9.setHeightForWidth(self.abl_active_chb.sizePolicy().hasHeightForWidth())
+        self.abl_active_chb.setSizePolicy(sizePolicy9)
+        self.abl_active_chb.setMinimumSize(QSize(0, 20))
+        self.abl_active_chb.setMaximumSize(QSize(16777215, 23))
+        self.abl_active_chb.setChecked(True)
+
+        self.horizontalLayout_11.addWidget(self.abl_active_chb)
+
+
+        self.probeABLGridLayout.addLayout(self.horizontalLayout_11, 0, 1, 1, 1)
+
+
+        self.verticalLayout_17.addLayout(self.probeABLGridLayout)
+
+        self.line_3 = QFrame(self.tabWidgetPage2)
+        self.line_3.setObjectName(u"line_3")
+        self.line_3.setFrameShape(QFrame.Shape.HLine)
+        self.line_3.setFrameShadow(QFrame.Shadow.Sunken)
+
+        self.verticalLayout_17.addWidget(self.line_3)
+
+        self.stepsGridLayout = QGridLayout()
+        self.stepsGridLayout.setObjectName(u"stepsGridLayout")
+        self.stepsGridLayout.setVerticalSpacing(0)
+        self.min_l = QLabel(self.tabWidgetPage2)
+        self.min_l.setObjectName(u"min_l")
+        sizePolicy10 = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.MinimumExpanding)
         sizePolicy10.setHorizontalStretch(0)
         sizePolicy10.setVerticalStretch(0)
-        sizePolicy10.setHeightForWidth(self.serial_te.sizePolicy().hasHeightForWidth())
-        self.serial_te.setSizePolicy(sizePolicy10)
+        sizePolicy10.setHeightForWidth(self.min_l.sizePolicy().hasHeightForWidth())
+        self.min_l.setSizePolicy(sizePolicy10)
+        self.min_l.setMinimumSize(QSize(0, 20))
+        self.min_l.setMaximumSize(QSize(16777215, 23))
+        self.min_l.setFont(font)
+        self.min_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        self.stepsGridLayout.addWidget(self.min_l, 0, 1, 1, 1)
+
+        self.max_l = QLabel(self.tabWidgetPage2)
+        self.max_l.setObjectName(u"max_l")
+        sizePolicy10.setHeightForWidth(self.max_l.sizePolicy().hasHeightForWidth())
+        self.max_l.setSizePolicy(sizePolicy10)
+        self.max_l.setMinimumSize(QSize(0, 20))
+        self.max_l.setMaximumSize(QSize(16777215, 23))
+        self.max_l.setFont(font)
+        self.max_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        self.stepsGridLayout.addWidget(self.max_l, 0, 2, 1, 1)
+
+        self.step_l = QLabel(self.tabWidgetPage2)
+        self.step_l.setObjectName(u"step_l")
+        sizePolicy10.setHeightForWidth(self.step_l.sizePolicy().hasHeightForWidth())
+        self.step_l.setSizePolicy(sizePolicy10)
+        self.step_l.setMinimumSize(QSize(0, 20))
+        self.step_l.setMaximumSize(QSize(16777215, 23))
+        self.step_l.setFont(font)
+        self.step_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        self.stepsGridLayout.addWidget(self.step_l, 0, 3, 1, 1)
+
+        self.n_step_l = QLabel(self.tabWidgetPage2)
+        self.n_step_l.setObjectName(u"n_step_l")
+        sizePolicy10.setHeightForWidth(self.n_step_l.sizePolicy().hasHeightForWidth())
+        self.n_step_l.setSizePolicy(sizePolicy10)
+        self.n_step_l.setMinimumSize(QSize(0, 20))
+        self.n_step_l.setMaximumSize(QSize(16777215, 23))
+        self.n_step_l.setFont(font)
+        self.n_step_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        self.stepsGridLayout.addWidget(self.n_step_l, 0, 4, 1, 1)
+
+        self.x_l = QLabel(self.tabWidgetPage2)
+        self.x_l.setObjectName(u"x_l")
+        sizePolicy10.setHeightForWidth(self.x_l.sizePolicy().hasHeightForWidth())
+        self.x_l.setSizePolicy(sizePolicy10)
+        self.x_l.setMinimumSize(QSize(0, 20))
+        self.x_l.setMaximumSize(QSize(16777215, 23))
+        self.x_l.setFont(font)
+        self.x_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        self.stepsGridLayout.addWidget(self.x_l, 1, 0, 1, 1)
+
+        self.x_min_dsb = QDoubleSpinBox(self.tabWidgetPage2)
+        self.x_min_dsb.setObjectName(u"x_min_dsb")
+        sizePolicy9.setHeightForWidth(self.x_min_dsb.sizePolicy().hasHeightForWidth())
+        self.x_min_dsb.setSizePolicy(sizePolicy9)
+        self.x_min_dsb.setMinimumSize(QSize(0, 20))
+        self.x_min_dsb.setMaximumSize(QSize(16777215, 23))
+        self.x_min_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.x_min_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+        self.x_min_dsb.setMinimum(-1000.000000000000000)
+        self.x_min_dsb.setMaximum(1000.000000000000000)
+
+        self.stepsGridLayout.addWidget(self.x_min_dsb, 1, 1, 1, 1)
+
+        self.x_max_dsb = QDoubleSpinBox(self.tabWidgetPage2)
+        self.x_max_dsb.setObjectName(u"x_max_dsb")
+        sizePolicy9.setHeightForWidth(self.x_max_dsb.sizePolicy().hasHeightForWidth())
+        self.x_max_dsb.setSizePolicy(sizePolicy9)
+        self.x_max_dsb.setMinimumSize(QSize(0, 20))
+        self.x_max_dsb.setMaximumSize(QSize(16777215, 23))
+        self.x_max_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.x_max_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+        self.x_max_dsb.setMinimum(-1000.000000000000000)
+        self.x_max_dsb.setMaximum(1000.000000000000000)
+
+        self.stepsGridLayout.addWidget(self.x_max_dsb, 1, 2, 1, 1)
+
+        self.x_step_dsb = QDoubleSpinBox(self.tabWidgetPage2)
+        self.x_step_dsb.setObjectName(u"x_step_dsb")
+        self.x_step_dsb.setEnabled(False)
+        sizePolicy9.setHeightForWidth(self.x_step_dsb.sizePolicy().hasHeightForWidth())
+        self.x_step_dsb.setSizePolicy(sizePolicy9)
+        self.x_step_dsb.setMinimumSize(QSize(0, 20))
+        self.x_step_dsb.setMaximumSize(QSize(16777215, 23))
+        self.x_step_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.x_step_dsb.setReadOnly(True)
+        self.x_step_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+
+        self.stepsGridLayout.addWidget(self.x_step_dsb, 1, 3, 1, 1)
+
+        self.x_num_step_sb = QSpinBox(self.tabWidgetPage2)
+        self.x_num_step_sb.setObjectName(u"x_num_step_sb")
+        sizePolicy9.setHeightForWidth(self.x_num_step_sb.sizePolicy().hasHeightForWidth())
+        self.x_num_step_sb.setSizePolicy(sizePolicy9)
+        self.x_num_step_sb.setMinimumSize(QSize(0, 20))
+        self.x_num_step_sb.setMaximumSize(QSize(16777215, 23))
+        self.x_num_step_sb.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.x_num_step_sb.setMinimum(4)
+
+        self.stepsGridLayout.addWidget(self.x_num_step_sb, 1, 4, 1, 1)
+
+        self.y_l = QLabel(self.tabWidgetPage2)
+        self.y_l.setObjectName(u"y_l")
+        sizePolicy10.setHeightForWidth(self.y_l.sizePolicy().hasHeightForWidth())
+        self.y_l.setSizePolicy(sizePolicy10)
+        self.y_l.setMinimumSize(QSize(0, 20))
+        self.y_l.setMaximumSize(QSize(16777215, 23))
+        self.y_l.setFont(font)
+        self.y_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        self.stepsGridLayout.addWidget(self.y_l, 2, 0, 1, 1)
+
+        self.y_min_dsb = QDoubleSpinBox(self.tabWidgetPage2)
+        self.y_min_dsb.setObjectName(u"y_min_dsb")
+        sizePolicy9.setHeightForWidth(self.y_min_dsb.sizePolicy().hasHeightForWidth())
+        self.y_min_dsb.setSizePolicy(sizePolicy9)
+        self.y_min_dsb.setMinimumSize(QSize(0, 20))
+        self.y_min_dsb.setMaximumSize(QSize(16777215, 23))
+        self.y_min_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.y_min_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+        self.y_min_dsb.setMinimum(-1000.000000000000000)
+        self.y_min_dsb.setMaximum(1000.000000000000000)
+
+        self.stepsGridLayout.addWidget(self.y_min_dsb, 2, 1, 1, 1)
+
+        self.y_max_dsb = QDoubleSpinBox(self.tabWidgetPage2)
+        self.y_max_dsb.setObjectName(u"y_max_dsb")
+        sizePolicy9.setHeightForWidth(self.y_max_dsb.sizePolicy().hasHeightForWidth())
+        self.y_max_dsb.setSizePolicy(sizePolicy9)
+        self.y_max_dsb.setMinimumSize(QSize(0, 20))
+        self.y_max_dsb.setMaximumSize(QSize(16777215, 23))
+        self.y_max_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.y_max_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+        self.y_max_dsb.setMinimum(-1000.000000000000000)
+        self.y_max_dsb.setMaximum(1000.000000000000000)
+
+        self.stepsGridLayout.addWidget(self.y_max_dsb, 2, 2, 1, 1)
+
+        self.y_step_dsb = QDoubleSpinBox(self.tabWidgetPage2)
+        self.y_step_dsb.setObjectName(u"y_step_dsb")
+        self.y_step_dsb.setEnabled(False)
+        sizePolicy9.setHeightForWidth(self.y_step_dsb.sizePolicy().hasHeightForWidth())
+        self.y_step_dsb.setSizePolicy(sizePolicy9)
+        self.y_step_dsb.setMinimumSize(QSize(0, 20))
+        self.y_step_dsb.setMaximumSize(QSize(16777215, 23))
+        self.y_step_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.y_step_dsb.setReadOnly(True)
+        self.y_step_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+
+        self.stepsGridLayout.addWidget(self.y_step_dsb, 2, 3, 1, 1)
+
+        self.y_num_step_sb = QSpinBox(self.tabWidgetPage2)
+        self.y_num_step_sb.setObjectName(u"y_num_step_sb")
+        sizePolicy9.setHeightForWidth(self.y_num_step_sb.sizePolicy().hasHeightForWidth())
+        self.y_num_step_sb.setSizePolicy(sizePolicy9)
+        self.y_num_step_sb.setMinimumSize(QSize(0, 20))
+        self.y_num_step_sb.setMaximumSize(QSize(16777215, 23))
+        self.y_num_step_sb.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.y_num_step_sb.setMinimum(4)
+
+        self.stepsGridLayout.addWidget(self.y_num_step_sb, 2, 4, 1, 1)
+
+        self.z_l = QLabel(self.tabWidgetPage2)
+        self.z_l.setObjectName(u"z_l")
+        sizePolicy10.setHeightForWidth(self.z_l.sizePolicy().hasHeightForWidth())
+        self.z_l.setSizePolicy(sizePolicy10)
+        self.z_l.setMinimumSize(QSize(0, 20))
+        self.z_l.setMaximumSize(QSize(16777215, 23))
+        self.z_l.setFont(font)
+        self.z_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        self.stepsGridLayout.addWidget(self.z_l, 3, 0, 1, 1)
+
+        self.z_min_dsb = QDoubleSpinBox(self.tabWidgetPage2)
+        self.z_min_dsb.setObjectName(u"z_min_dsb")
+        sizePolicy9.setHeightForWidth(self.z_min_dsb.sizePolicy().hasHeightForWidth())
+        self.z_min_dsb.setSizePolicy(sizePolicy9)
+        self.z_min_dsb.setMinimumSize(QSize(0, 20))
+        self.z_min_dsb.setMaximumSize(QSize(16777215, 23))
+        self.z_min_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.z_min_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+        self.z_min_dsb.setMinimum(-1000.000000000000000)
+        self.z_min_dsb.setMaximum(1000.000000000000000)
+
+        self.stepsGridLayout.addWidget(self.z_min_dsb, 3, 1, 1, 1)
+
+        self.z_max_dsb = QDoubleSpinBox(self.tabWidgetPage2)
+        self.z_max_dsb.setObjectName(u"z_max_dsb")
+        sizePolicy9.setHeightForWidth(self.z_max_dsb.sizePolicy().hasHeightForWidth())
+        self.z_max_dsb.setSizePolicy(sizePolicy9)
+        self.z_max_dsb.setMinimumSize(QSize(0, 20))
+        self.z_max_dsb.setMaximumSize(QSize(16777215, 23))
+        self.z_max_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.z_max_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+        self.z_max_dsb.setMinimum(-1000.000000000000000)
+        self.z_max_dsb.setMaximum(1000.000000000000000)
+
+        self.stepsGridLayout.addWidget(self.z_max_dsb, 3, 2, 1, 1)
+
+
+        self.verticalLayout_17.addLayout(self.stepsGridLayout)
+
+        self.line_4 = QFrame(self.tabWidgetPage2)
+        self.line_4.setObjectName(u"line_4")
+        self.line_4.setFrameShape(QFrame.Shape.HLine)
+        self.line_4.setFrameShadow(QFrame.Shadow.Sunken)
+
+        self.verticalLayout_17.addWidget(self.line_4)
+
+        self.serial_te = QTextEdit(self.tabWidgetPage2)
+        self.serial_te.setObjectName(u"serial_te")
+        self.serial_te.setEnabled(True)
+        sizePolicy11 = QSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.MinimumExpanding)
+        sizePolicy11.setHorizontalStretch(0)
+        sizePolicy11.setVerticalStretch(0)
+        sizePolicy11.setHeightForWidth(self.serial_te.sizePolicy().hasHeightForWidth())
+        self.serial_te.setSizePolicy(sizePolicy11)
         self.serial_te.setMinimumSize(QSize(0, 40))
         self.serial_te.setFrameShadow(QFrame.Shadow.Sunken)
         self.serial_te.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOn)
         self.serial_te.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByKeyboard|Qt.TextInteractionFlag.TextSelectableByMouse)
 
-        self.terminalVerticalLayout.addWidget(self.serial_te)
+        self.verticalLayout_17.addWidget(self.serial_te)
 
         self.horizontalLayout_2 = QHBoxLayout()
         self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
-        self.send_cb = ComboBoxFilterEnter(self.sender_tab)
+        self.send_cb = ComboBoxFilterEnter(self.tabWidgetPage2)
         self.send_cb.setObjectName(u"send_cb")
         sizePolicy2.setHeightForWidth(self.send_cb.sizePolicy().hasHeightForWidth())
         self.send_cb.setSizePolicy(sizePolicy2)
@@ -2197,45 +2226,45 @@ class Ui_MainWindow(object):
 
         self.horizontalLayout_2.addWidget(self.send_cb)
 
-        self.send_pb = QPushButton(self.sender_tab)
+        self.send_pb = QPushButton(self.tabWidgetPage2)
         self.send_pb.setObjectName(u"send_pb")
-        sizePolicy11 = QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
-        sizePolicy11.setHorizontalStretch(0)
-        sizePolicy11.setVerticalStretch(0)
-        sizePolicy11.setHeightForWidth(self.send_pb.sizePolicy().hasHeightForWidth())
-        self.send_pb.setSizePolicy(sizePolicy11)
+        sizePolicy12 = QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
+        sizePolicy12.setHorizontalStretch(0)
+        sizePolicy12.setVerticalStretch(0)
+        sizePolicy12.setHeightForWidth(self.send_pb.sizePolicy().hasHeightForWidth())
+        self.send_pb.setSizePolicy(sizePolicy12)
         self.send_pb.setFont(font)
 
         self.horizontalLayout_2.addWidget(self.send_pb)
 
 
-        self.terminalVerticalLayout.addLayout(self.horizontalLayout_2)
+        self.verticalLayout_17.addLayout(self.horizontalLayout_2)
 
         self.connectVerticalLayout = QVBoxLayout()
         self.connectVerticalLayout.setSpacing(6)
         self.connectVerticalLayout.setObjectName(u"connectVerticalLayout")
-        self.connectVerticalLayout.setContentsMargins(5, 0, 5, 0)
+        self.connectVerticalLayout.setContentsMargins(0, 0, 0, 0)
         self.horizontalLayout = QHBoxLayout()
         self.horizontalLayout.setSpacing(6)
         self.horizontalLayout.setObjectName(u"horizontalLayout")
-        self.serial_ports_cb = QComboBox(self.sender_tab)
+        self.serial_ports_cb = QComboBox(self.tabWidgetPage2)
         self.serial_ports_cb.setObjectName(u"serial_ports_cb")
         sizePolicy2.setHeightForWidth(self.serial_ports_cb.sizePolicy().hasHeightForWidth())
         self.serial_ports_cb.setSizePolicy(sizePolicy2)
 
         self.horizontalLayout.addWidget(self.serial_ports_cb)
 
-        self.serial_baud_cb = QComboBox(self.sender_tab)
+        self.serial_baud_cb = QComboBox(self.tabWidgetPage2)
         self.serial_baud_cb.setObjectName(u"serial_baud_cb")
         sizePolicy2.setHeightForWidth(self.serial_baud_cb.sizePolicy().hasHeightForWidth())
         self.serial_baud_cb.setSizePolicy(sizePolicy2)
 
         self.horizontalLayout.addWidget(self.serial_baud_cb)
 
-        self.refresh_pb = QPushButton(self.sender_tab)
+        self.refresh_pb = QPushButton(self.tabWidgetPage2)
         self.refresh_pb.setObjectName(u"refresh_pb")
-        sizePolicy11.setHeightForWidth(self.refresh_pb.sizePolicy().hasHeightForWidth())
-        self.refresh_pb.setSizePolicy(sizePolicy11)
+        sizePolicy2.setHeightForWidth(self.refresh_pb.sizePolicy().hasHeightForWidth())
+        self.refresh_pb.setSizePolicy(sizePolicy2)
         self.refresh_pb.setFont(font)
         self.refresh_pb.setCheckable(False)
 
@@ -2245,18 +2274,18 @@ class Ui_MainWindow(object):
         self.connectVerticalLayout.addLayout(self.horizontalLayout)
 
 
-        self.terminalVerticalLayout.addLayout(self.connectVerticalLayout)
+        self.verticalLayout_17.addLayout(self.connectVerticalLayout)
 
         self.horizontalLayout_9 = QHBoxLayout()
         self.horizontalLayout_9.setObjectName(u"horizontalLayout_9")
-        self.clear_terminal_pb = QPushButton(self.sender_tab)
+        self.clear_terminal_pb = QPushButton(self.tabWidgetPage2)
         self.clear_terminal_pb.setObjectName(u"clear_terminal_pb")
         self.clear_terminal_pb.setEnabled(True)
-        sizePolicy12 = QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Minimum)
-        sizePolicy12.setHorizontalStretch(0)
-        sizePolicy12.setVerticalStretch(0)
-        sizePolicy12.setHeightForWidth(self.clear_terminal_pb.sizePolicy().hasHeightForWidth())
-        self.clear_terminal_pb.setSizePolicy(sizePolicy12)
+        sizePolicy13 = QSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Minimum)
+        sizePolicy13.setHorizontalStretch(0)
+        sizePolicy13.setVerticalStretch(0)
+        sizePolicy13.setHeightForWidth(self.clear_terminal_pb.sizePolicy().hasHeightForWidth())
+        self.clear_terminal_pb.setSizePolicy(sizePolicy13)
         self.clear_terminal_pb.setFont(font)
 
         self.horizontalLayout_9.addWidget(self.clear_terminal_pb)
@@ -2265,7 +2294,7 @@ class Ui_MainWindow(object):
 
         self.horizontalLayout_9.addItem(self.horizontalSpacer_2)
 
-        self.connect_pb = QPushButton(self.sender_tab)
+        self.connect_pb = QPushButton(self.tabWidgetPage2)
         self.connect_pb.setObjectName(u"connect_pb")
         sizePolicy3.setHeightForWidth(self.connect_pb.sizePolicy().hasHeightForWidth())
         self.connect_pb.setSizePolicy(sizePolicy3)
@@ -2274,7 +2303,11 @@ class Ui_MainWindow(object):
         self.horizontalLayout_9.addWidget(self.connect_pb)
 
 
-        self.terminalVerticalLayout.addLayout(self.horizontalLayout_9)
+        self.verticalLayout_17.addLayout(self.horizontalLayout_9)
+
+        self.tabWidget.addTab(self.tabWidgetPage2, "")
+
+        self.terminalVerticalLayout.addWidget(self.tabWidget)
 
 
         self.controlsVerticalLayout.addLayout(self.terminalVerticalLayout)
@@ -2595,11 +2628,11 @@ class Ui_MainWindow(object):
         self.verticalLayout_13.setObjectName(u"verticalLayout_13")
         self.camera_la = QCameraLabel(self.frame)
         self.camera_la.setObjectName(u"camera_la")
-        sizePolicy13 = QSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.Expanding)
-        sizePolicy13.setHorizontalStretch(0)
-        sizePolicy13.setVerticalStretch(0)
-        sizePolicy13.setHeightForWidth(self.camera_la.sizePolicy().hasHeightForWidth())
-        self.camera_la.setSizePolicy(sizePolicy13)
+        sizePolicy14 = QSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.Expanding)
+        sizePolicy14.setHorizontalStretch(0)
+        sizePolicy14.setVerticalStretch(0)
+        sizePolicy14.setHeightForWidth(self.camera_la.sizePolicy().hasHeightForWidth())
+        self.camera_la.setSizePolicy(sizePolicy14)
         self.camera_la.setMinimumSize(QSize(200, 150))
         self.camera_la.setMaximumSize(QSize(480, 480))
 
@@ -3319,11 +3352,11 @@ class Ui_MainWindow(object):
 
         self.label_18 = QLabel(self.align_tab)
         self.label_18.setObjectName(u"label_18")
-        sizePolicy14 = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
-        sizePolicy14.setHorizontalStretch(0)
-        sizePolicy14.setVerticalStretch(0)
-        sizePolicy14.setHeightForWidth(self.label_18.sizePolicy().hasHeightForWidth())
-        self.label_18.setSizePolicy(sizePolicy14)
+        sizePolicy15 = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+        sizePolicy15.setHorizontalStretch(0)
+        sizePolicy15.setVerticalStretch(0)
+        sizePolicy15.setHeightForWidth(self.label_18.sizePolicy().hasHeightForWidth())
+        self.label_18.setSizePolicy(sizePolicy15)
         self.label_18.setMinimumSize(QSize(0, 20))
         self.label_18.setMaximumSize(QSize(16777215, 20))
         self.label_18.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -3608,8 +3641,8 @@ class Ui_MainWindow(object):
 
         self.z_feedrate_la = QLabel(self.jobs_machine_settings_tab)
         self.z_feedrate_la.setObjectName(u"z_feedrate_la")
-        sizePolicy14.setHeightForWidth(self.z_feedrate_la.sizePolicy().hasHeightForWidth())
-        self.z_feedrate_la.setSizePolicy(sizePolicy14)
+        sizePolicy15.setHeightForWidth(self.z_feedrate_la.sizePolicy().hasHeightForWidth())
+        self.z_feedrate_la.setSizePolicy(sizePolicy15)
         self.z_feedrate_la.setMinimumSize(QSize(130, 0))
         self.z_feedrate_la.setMaximumSize(QSize(130, 16777215))
         self.z_feedrate_la.setFont(font)
@@ -4268,8 +4301,8 @@ class Ui_MainWindow(object):
 
         self.logging_plain_te = QPlainTextEdit(self.central_widget)
         self.logging_plain_te.setObjectName(u"logging_plain_te")
-        sizePolicy10.setHeightForWidth(self.logging_plain_te.sizePolicy().hasHeightForWidth())
-        self.logging_plain_te.setSizePolicy(sizePolicy10)
+        sizePolicy11.setHeightForWidth(self.logging_plain_te.sizePolicy().hasHeightForWidth())
+        self.logging_plain_te.setSizePolicy(sizePolicy11)
         self.logging_plain_te.setMinimumSize(QSize(0, 40))
         self.logging_plain_te.setMaximumSize(QSize(16777215, 200))
         self.logging_plain_te.setReadOnly(True)
@@ -4398,6 +4431,7 @@ class Ui_MainWindow(object):
         self.prepare_widget.setCurrentIndex(1)
         self.jobs_sw.setCurrentIndex(0)
         self.ctrl_tab_widget.setCurrentIndex(1)
+        self.tabWidget.setCurrentIndex(1)
         self.z_step_cb.setCurrentIndex(3)
         self.xy_step_cb.setCurrentIndex(3)
         self.z_step_cb_2.setCurrentIndex(3)
@@ -4582,20 +4616,6 @@ class Ui_MainWindow(object):
         self.zero_x_pb.setText(QCoreApplication.translate("MainWindow", u"X = 0", None))
         self.y_axis_l.setText(QCoreApplication.translate("MainWindow", u"Y", None))
         self.mpos_x_l.setText(QCoreApplication.translate("MainWindow", u"0.0", None))
-        self.probe_pb.setText(QCoreApplication.translate("MainWindow", u"PROBE", None))
-        self.get_bbox_pb.setText(QCoreApplication.translate("MainWindow", u"GET BBOX", None))
-        self.ABL_pb.setText(QCoreApplication.translate("MainWindow", u"ABL", None))
-#if QT_CONFIG(tooltip)
-        self.abl_active_chb.setToolTip(QCoreApplication.translate("MainWindow", u"Apply ABL if checked", None))
-#endif // QT_CONFIG(tooltip)
-        self.abl_active_chb.setText("")
-        self.min_l.setText(QCoreApplication.translate("MainWindow", u"Min", None))
-        self.max_l.setText(QCoreApplication.translate("MainWindow", u"Max", None))
-        self.step_l.setText(QCoreApplication.translate("MainWindow", u"Step", None))
-        self.n_step_l.setText(QCoreApplication.translate("MainWindow", u"N", None))
-        self.x_l.setText(QCoreApplication.translate("MainWindow", u"X", None))
-        self.y_l.setText(QCoreApplication.translate("MainWindow", u"Y", None))
-        self.z_l.setText(QCoreApplication.translate("MainWindow", u"Z", None))
         self.z_plus_pb.setText(QCoreApplication.translate("MainWindow", u"Z+", None))
         self.z_minus_pb.setText(QCoreApplication.translate("MainWindow", u"Z-", None))
         self.x_minus_y_plus_pb.setText(QCoreApplication.translate("MainWindow", u"X- Y+", None))
@@ -4635,6 +4655,21 @@ class Ui_MainWindow(object):
         self.xy_div_10_pb.setText(QCoreApplication.translate("MainWindow", u"\u00f710", None))
         self.xy_mul_10_pb.setText(QCoreApplication.translate("MainWindow", u"x10", None))
         self.xy_minus_1_pb.setText(QCoreApplication.translate("MainWindow", u"-1.0", None))
+        self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab), QCoreApplication.translate("MainWindow", u"Jog", None))
+        self.probe_pb.setText(QCoreApplication.translate("MainWindow", u"PROBE", None))
+        self.get_bbox_pb.setText(QCoreApplication.translate("MainWindow", u"GET BBOX", None))
+        self.ABL_pb.setText(QCoreApplication.translate("MainWindow", u"ABL", None))
+#if QT_CONFIG(tooltip)
+        self.abl_active_chb.setToolTip(QCoreApplication.translate("MainWindow", u"Apply ABL if checked", None))
+#endif // QT_CONFIG(tooltip)
+        self.abl_active_chb.setText("")
+        self.min_l.setText(QCoreApplication.translate("MainWindow", u"Min", None))
+        self.max_l.setText(QCoreApplication.translate("MainWindow", u"Max", None))
+        self.step_l.setText(QCoreApplication.translate("MainWindow", u"Step", None))
+        self.n_step_l.setText(QCoreApplication.translate("MainWindow", u"N", None))
+        self.x_l.setText(QCoreApplication.translate("MainWindow", u"X", None))
+        self.y_l.setText(QCoreApplication.translate("MainWindow", u"Y", None))
+        self.z_l.setText(QCoreApplication.translate("MainWindow", u"Z", None))
         self.send_pb.setText(QCoreApplication.translate("MainWindow", u"Send", None))
 #if QT_CONFIG(tooltip)
         self.serial_ports_cb.setToolTip(QCoreApplication.translate("MainWindow", u"Available serial ports.", None))
@@ -4658,6 +4693,7 @@ class Ui_MainWindow(object):
         self.connect_pb.setStatusTip(QCoreApplication.translate("MainWindow", u"Connect to selected serial port.", None))
 #endif // QT_CONFIG(statustip)
         self.connect_pb.setText(QCoreApplication.translate("MainWindow", u"Connect", None))
+        self.tabWidget.setTabText(self.tabWidget.indexOf(self.tabWidgetPage2), QCoreApplication.translate("MainWindow", u"Probe/Terminal", None))
         self.ctrl_tab_widget.setTabText(self.ctrl_tab_widget.indexOf(self.sender_tab), QCoreApplication.translate("MainWindow", u"Sender", None))
 #if QT_CONFIG(tooltip)
         self.probe_led_la.setToolTip(QCoreApplication.translate("MainWindow", u"Probe in idle", None))

--- a/tests/unit/test_settings_manager.py
+++ b/tests/unit/test_settings_manager.py
@@ -26,6 +26,7 @@ class TestAppSettingsHandler:
         mock_ui.main_tab_widget.currentIndex.return_value = 0
         mock_ui.ctrl_tab_widget.currentIndex.return_value = 0
         mock_ui.settings_sub_tab.currentIndex.return_value = 0
+        mock_ui.jog_probe_tab_widget.currentIndex.return_value = 0
         mock_ui.actionHide_Show_Align_Tab.isChecked.return_value = False
         mock_ui.actionSettings_Preferences.isChecked.return_value = False
         mock_ui.actionHide_Show_Console.isChecked.return_value = False


### PR DESCRIPTION
Inserted tab widget in sender tab, dividing jog ui from probe and terminal ui, to have better order of sender tab