### PR TITLE
Better serial error management

### DIFF
--- a/src/TheAntFarm/serial_manager.py
+++ b/src/TheAntFarm/serial_manager.py
@@ -28,6 +28,12 @@ class SerialWorker(QObject):
         self.count_queue_sent = 0
         self.count_sent = 0
 
+        # Error handling configuration
+        self._consecutive_errors = 0
+        self._warning_threshold = 3  # Log errors after this many consecutive errors
+        self._critical_threshold = 10  # Close port after this many consecutive errors
+        self._last_error_type = None
+
     @Slot()
     def get_port_list(self):
         """Return serial port list."""
@@ -63,6 +69,7 @@ class SerialWorker(QObject):
         """Close serial port."""
         logger.debug("Closing " + self.serial_port.portName())
         self.update_console_text_s.emit("Closing " + self.serial_port.portName())
+        self.reset_error_count()
         self.serial_port.close()
 
     @Slot()
@@ -140,7 +147,30 @@ class SerialWorker(QObject):
     def serial_error_manager(self):
         error_type = self.serial_port.error()
         if error_type != QSerialPort.SerialPortError.NoError:
-            logger.error(self.serial_port.error())
-            logger.error(self.serial_port.errorString())
-            # if error_type == QSerialPort.ResourceError:
-            #     self.close_for_error_s.emit()
+            error_msg = self.serial_port.errorString()
+
+            # Reset counter if error type changes
+            if error_type != self._last_error_type:
+                self._consecutive_errors = 0
+                self._last_error_type = error_type
+
+            self._consecutive_errors += 1
+
+            # Handle different error thresholds
+            if self._consecutive_errors >= self._critical_threshold:
+                logger.error(f"Critical error: {error_type} - {error_msg}")
+                logger.error("Too many consecutive errors, closing port")
+                self.update_console_text_s.emit(f"Critical error: {error_msg}")
+                self.close_for_error_s.emit()
+            elif self._consecutive_errors >= self._warning_threshold:
+                logger.error(f"Serial error: {error_type} - {error_msg}")
+                self.update_console_text_s.emit(f"Warning: {error_msg}")
+        else:
+            # Reset counters when no error occurs
+            self._consecutive_errors = 0
+            self._last_error_type = None
+
+    def reset_error_count(self):
+        """Reset error counters when connection is manually managed"""
+        self._consecutive_errors = 0
+        self._last_error_type = None

--- a/src/TheAntFarm/settings_manager/settings_app.py
+++ b/src/TheAntFarm/settings_manager/settings_app.py
@@ -38,6 +38,8 @@ class AppSettingsHandler:
     CAMERA_SELECTED_OR_TOOL_DEFAULT = False  # Default selection should be tool, camera could be absent
     FLIP_HORIZONTAL_SELECTED_DEFAULT = False
     FLIP_VERTICAL_SELECTED_DEFAULT = False
+    SERIAL_ERROR_WARNING_THRESHOLD_DEFAULT = 3
+    SERIAL_ERROR_CRITICAL_THRESHOLD_DEFAULT = 10
 
     def __init__(self, config_folder, main_win):
 
@@ -95,6 +97,8 @@ class AppSettingsHandler:
         self.camera_selected_or_tool = self.CAMERA_SELECTED_OR_TOOL_DEFAULT
         self.flip_horizontal_selected = self.FLIP_HORIZONTAL_SELECTED_DEFAULT
         self.flip_vertical_selected = self.FLIP_VERTICAL_SELECTED_DEFAULT
+        self.serial_error_warning_threshold = self.SERIAL_ERROR_WARNING_THRESHOLD_DEFAULT
+        self.serial_error_critical_threshold = self.SERIAL_ERROR_CRITICAL_THRESHOLD_DEFAULT
 
     @staticmethod
     def choose_version(version_s, version_default_s):
@@ -194,6 +198,10 @@ class AppSettingsHandler:
                                                                    self.FLIP_HORIZONTAL_SELECTED_DEFAULT)
             self.flip_vertical_selected = app_general.getboolean("flip_vertical_selected",
                                                                  self.FLIP_VERTICAL_SELECTED_DEFAULT)
+            self.serial_error_warning_threshold = app_general.getint("serial_error_warning_threshold",
+                                                                     self.SERIAL_ERROR_WARNING_THRESHOLD_DEFAULT)
+            self.serial_error_critical_threshold = app_general.getint("serial_error_critical_threshold",
+                                                                      self.SERIAL_ERROR_CRITICAL_THRESHOLD_DEFAULT)
 
         # Layers related application settings #
         if "LAYERS" in self.app_settings:
@@ -243,7 +251,9 @@ class AppSettingsHandler:
                                         "last_serial_baud": self.LAST_SERIAL_BAUD_DEFAULT,
                                         "camera_selected_or_tool": self.CAMERA_SELECTED_OR_TOOL_DEFAULT,
                                         "flip_horizontal_selected": self.FLIP_HORIZONTAL_SELECTED_DEFAULT,
-                                        "flip_vertical_selected": self.FLIP_VERTICAL_SELECTED_DEFAULT}
+                                        "flip_vertical_selected": self.FLIP_VERTICAL_SELECTED_DEFAULT,
+                                        "serial_error_warning_threshold": self.SERIAL_ERROR_WARNING_THRESHOLD_DEFAULT,
+                                        "serial_error_critical_threshold": self.SERIAL_ERROR_CRITICAL_THRESHOLD_DEFAULT}
 
         # GENERAL application settings #
         self.app_settings["GENERAL"] = {}
@@ -270,6 +280,8 @@ class AppSettingsHandler:
         app_general["camera_selected_or_tool"] = str(self.camera_selected_or_tool)
         app_general["flip_horizontal_selected"] = str(self.main_win.ui.flip_horizontally_tb.isChecked())
         app_general["flip_vertical_selected"] = str(self.main_win.ui.flip_vertically_tb.isChecked())
+        app_general["serial_error_warning_threshold"] = str(self.serial_error_warning_threshold)
+        app_general["serial_error_critical_threshold"] = str(self.serial_error_critical_threshold)
 
         # Layers related application settings #
         self.app_settings["LAYERS"] = {}
@@ -321,7 +333,9 @@ class AppSettingsHandler:
                                         "last_serial_port": self.LAST_SERIAL_PORT_DEFAULT,
                                         "last_serial_baud": self.LAST_SERIAL_BAUD_DEFAULT,
                                         "flip_horizontal_selected": self.FLIP_HORIZONTAL_SELECTED_DEFAULT,
-                                        "flip_vertical_selected": self.FLIP_VERTICAL_SELECTED_DEFAULT}
+                                        "flip_vertical_selected": self.FLIP_VERTICAL_SELECTED_DEFAULT,
+                                        "serial_error_warning_threshold": self.SERIAL_ERROR_WARNING_THRESHOLD_DEFAULT,
+                                        "serial_error_critical_threshold": self.SERIAL_ERROR_CRITICAL_THRESHOLD_DEFAULT}
 
         # GENERAL application settings #
         self.app_settings["GENERAL"] = {}
@@ -345,6 +359,8 @@ class AppSettingsHandler:
         app_general["camera_selected_or_tool"] = str(self.CAMERA_SELECTED_OR_TOOL_DEFAULT)
         app_general["flip_horizontal_selected"] = str(self.main_win.ui.flip_horizontally_tb.isChecked())
         app_general["flip_vertical_selected"] = str(self.main_win.ui.flip_vertically_tb.isChecked())
+        app_general["serial_error_warning_threshold"] = str(self.SERIAL_ERROR_WARNING_THRESHOLD_DEFAULT)
+        app_general["serial_error_critical_threshold"] = str(self.SERIAL_ERROR_CRITICAL_THRESHOLD_DEFAULT)
 
         # Layers related application settings #
         self.app_settings["LAYERS"] = {}

--- a/src/TheAntFarm/settings_manager/settings_app.py
+++ b/src/TheAntFarm/settings_manager/settings_app.py
@@ -202,6 +202,15 @@ class AppSettingsHandler:
                                                                      self.SERIAL_ERROR_WARNING_THRESHOLD_DEFAULT)
             self.serial_error_critical_threshold = app_general.getint("serial_error_critical_threshold",
                                                                       self.SERIAL_ERROR_CRITICAL_THRESHOLD_DEFAULT)
+            # Validate thresholds are >= 0
+            if self.serial_error_warning_threshold < 0:
+                self.serial_error_warning_threshold = self.SERIAL_ERROR_WARNING_THRESHOLD_DEFAULT
+            if self.serial_error_critical_threshold < 0:
+                self.serial_error_critical_threshold = self.SERIAL_ERROR_CRITICAL_THRESHOLD_DEFAULT
+            # Ensure warning <= critical
+            if self.serial_error_warning_threshold > self.serial_error_critical_threshold:
+                self.serial_error_warning_threshold = self.SERIAL_ERROR_WARNING_THRESHOLD_DEFAULT
+                self.serial_error_critical_threshold = self.SERIAL_ERROR_CRITICAL_THRESHOLD_DEFAULT
 
         # Layers related application settings #
         if "LAYERS" in self.app_settings:

--- a/src/TheAntFarm/the_ant_farm.ui
+++ b/src/TheAntFarm/the_ant_farm.ui
@@ -48,10 +48,10 @@
        </font>
       </property>
       <property name="tabShape">
-       <enum>QTabWidget::TabShape::Rounded</enum>
+       <enum>QTabWidget::Rounded</enum>
       </property>
       <property name="currentIndex">
-       <number>1</number>
+       <number>3</number>
       </property>
       <property name="tabsClosable">
        <bool>false</bool>
@@ -82,10 +82,10 @@
                </sizepolicy>
               </property>
               <property name="tabPosition">
-               <enum>QTabWidget::TabPosition::North</enum>
+               <enum>QTabWidget::North</enum>
               </property>
               <property name="tabShape">
-               <enum>QTabWidget::TabShape::Rounded</enum>
+               <enum>QTabWidget::Rounded</enum>
               </property>
               <property name="currentIndex">
                <number>1</number>
@@ -98,7 +98,7 @@
                 <item>
                  <layout class="QGridLayout" name="gridLayout">
                   <property name="sizeConstraint">
-                   <enum>QLayout::SizeConstraint::SetFixedSize</enum>
+                   <enum>QLayout::SetDefaultConstraint</enum>
                   </property>
                   <item row="5" column="0">
                    <widget class="QLineEdit" name="no_copper_1_le">
@@ -132,7 +132,7 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="6" column="2" alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <item row="6" column="2">
                    <widget class="QCheckBox" name="no_copper_2_chb">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -161,7 +161,7 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="0" column="2" alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <item row="0" column="2">
                    <widget class="QLabel" name="view_label">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -172,12 +172,9 @@
                     <property name="text">
                      <string>View</string>
                     </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
                    </widget>
                   </item>
-                  <item row="1" column="2" alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <item row="1" column="2">
                    <widget class="QCheckBox" name="top_view_chb">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -225,7 +222,7 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="2" column="2" alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <item row="2" column="2">
                    <widget class="QCheckBox" name="bottom_view_chb">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -267,7 +264,7 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="5" column="2" alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <item row="5" column="2">
                    <widget class="QCheckBox" name="no_copper_1_chb">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -348,7 +345,7 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="4" column="2" alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <item row="4" column="2">
                    <widget class="QCheckBox" name="drill_view_chb">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -364,7 +361,7 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="0" column="0" alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <item row="0" column="0">
                    <widget class="QLabel" name="file_path_l">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -390,7 +387,7 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="8" column="2" alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <item row="8" column="2">
                    <widget class="QCheckBox" name="all_view_chb">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -406,7 +403,7 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="3" column="2" alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <item row="3" column="2">
                    <widget class="QCheckBox" name="profile_view_chb">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -424,11 +421,8 @@
                   </item>
                   <item row="8" column="0">
                    <spacer name="horizontal_spacer">
-                    <property name="orientation">
-                     <enum>Qt::Orientation::Horizontal</enum>
-                    </property>
                     <property name="sizeType">
-                     <enum>QSizePolicy::Policy::Expanding</enum>
+                     <enum>QSizePolicy::Fixed</enum>
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
@@ -440,9 +434,6 @@
                   </item>
                   <item row="7" column="0">
                    <spacer name="horizontal_spacer_2">
-                    <property name="orientation">
-                     <enum>Qt::Orientation::Horizontal</enum>
-                    </property>
                     <property name="sizeHint" stdset="0">
                      <size>
                       <width>40</width>
@@ -455,9 +446,6 @@
                 </item>
                 <item>
                  <spacer name="verticalSpacer">
-                  <property name="orientation">
-                   <enum>Qt::Orientation::Vertical</enum>
-                  </property>
                   <property name="sizeHint" stdset="0">
                    <size>
                     <width>20</width>
@@ -539,9 +527,6 @@
                     </item>
                     <item row="10" column="0" colspan="2">
                      <spacer name="top_vertical_spacer">
-                      <property name="orientation">
-                       <enum>Qt::Orientation::Vertical</enum>
-                      </property>
                       <property name="sizeHint" stdset="0">
                        <size>
                         <width>20</width>
@@ -631,7 +616,7 @@
                        <double>0.000100000000000</double>
                       </property>
                       <property name="stepType">
-                       <enum>QAbstractSpinBox::StepType::DefaultStepType</enum>
+                       <enum>QAbstractSpinBox::DefaultStepType</enum>
                       </property>
                      </widget>
                     </item>
@@ -824,9 +809,6 @@
                     </item>
                     <item row="11" column="0" colspan="2">
                      <spacer name="bottom_vertical_spacer">
-                      <property name="orientation">
-                       <enum>Qt::Orientation::Vertical</enum>
-                      </property>
                       <property name="sizeHint" stdset="0">
                        <size>
                         <width>20</width>
@@ -1064,7 +1046,7 @@
                       </property>
                      </widget>
                     </item>
-                    <item row="2" column="3" alignment="Qt::AlignmentFlag::AlignHCenter">
+                    <item row="2" column="3">
                      <widget class="QCheckBox" name="profile_multi_depth_chb">
                       <property name="sizePolicy">
                        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -1118,9 +1100,6 @@
                     </item>
                     <item row="15" column="1" colspan="3">
                      <spacer name="profile_vertical_spacer">
-                      <property name="orientation">
-                       <enum>Qt::Orientation::Vertical</enum>
-                      </property>
                       <property name="sizeHint" stdset="0">
                        <size>
                         <width>20</width>
@@ -1241,7 +1220,7 @@
                       </property>
                      </widget>
                     </item>
-                    <item row="2" column="1" alignment="Qt::AlignmentFlag::AlignHCenter">
+                    <item row="2" column="1">
                      <widget class="QToolButton" name="add_drill_tool_tb">
                       <property name="text">
                        <string>+</string>
@@ -1295,7 +1274,7 @@
                       </property>
                      </widget>
                     </item>
-                    <item row="2" column="2" alignment="Qt::AlignmentFlag::AlignHCenter">
+                    <item row="2" column="2">
                      <widget class="QToolButton" name="remove_drill_tool_tb">
                       <property name="text">
                        <string>-</string>
@@ -1332,10 +1311,10 @@
                       </property>
                      </widget>
                     </item>
-                    <item row="0" column="1" colspan="2" alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                    <item row="0" column="1" colspan="2">
                      <widget class="QTableWidget" name="drill_tw">
                       <property name="selectionBehavior">
-                       <enum>QAbstractItemView::SelectionBehavior::SelectRows</enum>
+                       <enum>QAbstractItemView::SelectItems</enum>
                       </property>
                       <property name="columnCount">
                        <number>2</number>
@@ -1416,9 +1395,6 @@
                     </item>
                     <item row="15" column="1" colspan="2">
                      <spacer name="drill_vertical_spacer">
-                      <property name="orientation">
-                       <enum>Qt::Orientation::Vertical</enum>
-                      </property>
                       <property name="sizeHint" stdset="0">
                        <size>
                         <width>20</width>
@@ -1655,9 +1631,6 @@
                     </item>
                     <item row="7" column="0" colspan="2">
                      <spacer name="nc_top_vertical_spacer">
-                      <property name="orientation">
-                       <enum>Qt::Orientation::Vertical</enum>
-                      </property>
                       <property name="sizeHint" stdset="0">
                        <size>
                         <width>20</width>
@@ -1791,9 +1764,6 @@
                     </item>
                     <item row="8" column="0" colspan="2">
                      <spacer name="nc_bottom_vertical_spacer">
-                      <property name="orientation">
-                       <enum>Qt::Orientation::Vertical</enum>
-                      </property>
                       <property name="sizeHint" stdset="0">
                        <size>
                         <width>20</width>
@@ -1893,9 +1863,6 @@
              <layout class="QHBoxLayout" name="horizontalLayout_3">
               <item>
                <spacer name="horizontalSpacer">
-                <property name="orientation">
-                 <enum>Qt::Orientation::Horizontal</enum>
-                </property>
                 <property name="sizeHint" stdset="0">
                  <size>
                   <width>40</width>
@@ -2002,16 +1969,16 @@
                  </size>
                 </property>
                 <property name="frameShape">
-                 <enum>QFrame::Shape::NoFrame</enum>
+                 <enum>QFrame::NoFrame</enum>
                 </property>
                 <property name="horizontalScrollBarPolicy">
-                 <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
+                 <enum>Qt::ScrollBarAsNeeded</enum>
                 </property>
                 <property name="selectionMode">
-                 <enum>QAbstractItemView::SelectionMode::MultiSelection</enum>
+                 <enum>QAbstractItemView::NoSelection</enum>
                 </property>
                 <property name="selectionBehavior">
-                 <enum>QAbstractItemView::SelectionBehavior::SelectRows</enum>
+                 <enum>QAbstractItemView::SelectItems</enum>
                 </property>
                 <property name="showGrid">
                  <bool>false</bool>
@@ -2144,7 +2111,7 @@
               <item>
                <layout class="QVBoxLayout" name="controlsVerticalLayout" stretch="0,0,0">
                 <property name="sizeConstraint">
-                 <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+                 <enum>QLayout::SetDefaultConstraint</enum>
                 </property>
                 <item>
                  <layout class="QGridLayout" name="droGridLayout">
@@ -2166,7 +2133,7 @@
                   <property name="verticalSpacing">
                    <number>2</number>
                   </property>
-                  <item row="3" column="0" alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                  <item row="3" column="0">
                    <widget class="QPushButton" name="zero_xy_pb">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -2196,7 +2163,7 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="3" column="2" alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <item row="3" column="2">
                    <widget class="QPushButton" name="zero_y_pb">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -2226,7 +2193,7 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="0" column="3" alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <item row="0" column="3">
                    <widget class="QLabel" name="z_axis_l">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -2252,23 +2219,17 @@
                      </font>
                     </property>
                     <property name="layoutDirection">
-                     <enum>Qt::LayoutDirection::LeftToRight</enum>
+                     <enum>Qt::LeftToRight</enum>
                     </property>
                     <property name="frameShape">
-                     <enum>QFrame::Shape::NoFrame</enum>
-                    </property>
-                    <property name="frameShadow">
-                     <enum>QFrame::Shadow::Plain</enum>
+                     <enum>QFrame::NoFrame</enum>
                     </property>
                     <property name="text">
                      <string>Z</string>
                     </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
                    </widget>
                   </item>
-                  <item row="2" column="2" alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <item row="2" column="2">
                    <widget class="QLabel" name="wpos_y_l">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -2289,23 +2250,17 @@
                      </size>
                     </property>
                     <property name="layoutDirection">
-                     <enum>Qt::LayoutDirection::LeftToRight</enum>
+                     <enum>Qt::LeftToRight</enum>
                     </property>
                     <property name="frameShape">
-                     <enum>QFrame::Shape::NoFrame</enum>
-                    </property>
-                    <property name="frameShadow">
-                     <enum>QFrame::Shadow::Plain</enum>
+                     <enum>QFrame::NoFrame</enum>
                     </property>
                     <property name="text">
                      <string>0.0</string>
                     </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
                    </widget>
                   </item>
-                  <item row="2" column="0" alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                  <item row="2" column="0">
                    <widget class="QLabel" name="wpos_l">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -2331,23 +2286,17 @@
                      </font>
                     </property>
                     <property name="layoutDirection">
-                     <enum>Qt::LayoutDirection::LeftToRight</enum>
+                     <enum>Qt::LeftToRight</enum>
                     </property>
                     <property name="frameShape">
-                     <enum>QFrame::Shape::NoFrame</enum>
-                    </property>
-                    <property name="frameShadow">
-                     <enum>QFrame::Shadow::Plain</enum>
+                     <enum>QFrame::NoFrame</enum>
                     </property>
                     <property name="text">
                      <string>WPos</string>
                     </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
                    </widget>
                   </item>
-                  <item row="3" column="3" alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                  <item row="3" column="3">
                    <widget class="QPushButton" name="zero_z_pb">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -2377,7 +2326,7 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="1" column="2" alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <item row="1" column="2">
                    <widget class="QLabel" name="mpos_y_l">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -2398,23 +2347,17 @@
                      </size>
                     </property>
                     <property name="layoutDirection">
-                     <enum>Qt::LayoutDirection::LeftToRight</enum>
+                     <enum>Qt::LeftToRight</enum>
                     </property>
                     <property name="frameShape">
-                     <enum>QFrame::Shape::NoFrame</enum>
-                    </property>
-                    <property name="frameShadow">
-                     <enum>QFrame::Shadow::Plain</enum>
+                     <enum>QFrame::NoFrame</enum>
                     </property>
                     <property name="text">
                      <string>0.0</string>
                     </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
                    </widget>
                   </item>
-                  <item row="1" column="3" alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <item row="1" column="3">
                    <widget class="QLabel" name="mpos_z_l">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -2435,23 +2378,17 @@
                      </size>
                     </property>
                     <property name="layoutDirection">
-                     <enum>Qt::LayoutDirection::LeftToRight</enum>
+                     <enum>Qt::LeftToRight</enum>
                     </property>
                     <property name="frameShape">
-                     <enum>QFrame::Shape::NoFrame</enum>
-                    </property>
-                    <property name="frameShadow">
-                     <enum>QFrame::Shadow::Plain</enum>
+                     <enum>QFrame::NoFrame</enum>
                     </property>
                     <property name="text">
                      <string>0.0</string>
                     </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
                    </widget>
                   </item>
-                  <item row="0" column="1" alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                  <item row="0" column="1">
                    <widget class="QLabel" name="x_axis_l">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -2477,23 +2414,17 @@
                      </font>
                     </property>
                     <property name="layoutDirection">
-                     <enum>Qt::LayoutDirection::LeftToRight</enum>
+                     <enum>Qt::LeftToRight</enum>
                     </property>
                     <property name="frameShape">
-                     <enum>QFrame::Shape::NoFrame</enum>
-                    </property>
-                    <property name="frameShadow">
-                     <enum>QFrame::Shadow::Plain</enum>
+                     <enum>QFrame::NoFrame</enum>
                     </property>
                     <property name="text">
                      <string>X</string>
                     </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
                    </widget>
                   </item>
-                  <item row="2" column="1" alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                  <item row="2" column="1">
                    <widget class="QLabel" name="wpos_x_l">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -2514,23 +2445,17 @@
                      </size>
                     </property>
                     <property name="layoutDirection">
-                     <enum>Qt::LayoutDirection::LeftToRight</enum>
+                     <enum>Qt::LeftToRight</enum>
                     </property>
                     <property name="frameShape">
-                     <enum>QFrame::Shape::NoFrame</enum>
-                    </property>
-                    <property name="frameShadow">
-                     <enum>QFrame::Shadow::Plain</enum>
+                     <enum>QFrame::NoFrame</enum>
                     </property>
                     <property name="text">
                      <string>0.0</string>
                     </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
                    </widget>
                   </item>
-                  <item row="0" column="0" alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                  <item row="0" column="0">
                    <widget class="QLabel" name="axis_l">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -2556,23 +2481,17 @@
                      </font>
                     </property>
                     <property name="layoutDirection">
-                     <enum>Qt::LayoutDirection::LeftToRight</enum>
+                     <enum>Qt::LeftToRight</enum>
                     </property>
                     <property name="frameShape">
-                     <enum>QFrame::Shape::NoFrame</enum>
-                    </property>
-                    <property name="frameShadow">
-                     <enum>QFrame::Shadow::Plain</enum>
+                     <enum>QFrame::NoFrame</enum>
                     </property>
                     <property name="text">
                      <string>Axis:</string>
                     </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
                    </widget>
                   </item>
-                  <item row="1" column="0" alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                  <item row="1" column="0">
                    <widget class="QLabel" name="mpos_l">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -2598,23 +2517,17 @@
                      </font>
                     </property>
                     <property name="layoutDirection">
-                     <enum>Qt::LayoutDirection::LeftToRight</enum>
+                     <enum>Qt::LeftToRight</enum>
                     </property>
                     <property name="frameShape">
-                     <enum>QFrame::Shape::NoFrame</enum>
-                    </property>
-                    <property name="frameShadow">
-                     <enum>QFrame::Shadow::Plain</enum>
+                     <enum>QFrame::NoFrame</enum>
                     </property>
                     <property name="text">
                      <string>MPos</string>
                     </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
                    </widget>
                   </item>
-                  <item row="2" column="3" alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <item row="2" column="3">
                    <widget class="QLabel" name="wpos_z_l">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -2635,23 +2548,17 @@
                      </size>
                     </property>
                     <property name="layoutDirection">
-                     <enum>Qt::LayoutDirection::LeftToRight</enum>
+                     <enum>Qt::LeftToRight</enum>
                     </property>
                     <property name="frameShape">
-                     <enum>QFrame::Shape::NoFrame</enum>
-                    </property>
-                    <property name="frameShadow">
-                     <enum>QFrame::Shadow::Plain</enum>
+                     <enum>QFrame::NoFrame</enum>
                     </property>
                     <property name="text">
                      <string>0.0</string>
                     </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
                    </widget>
                   </item>
-                  <item row="3" column="1" alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                  <item row="3" column="1">
                    <widget class="QPushButton" name="zero_x_pb">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -2681,7 +2588,7 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="0" column="2" alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                  <item row="0" column="2">
                    <widget class="QLabel" name="y_axis_l">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -2707,23 +2614,17 @@
                      </font>
                     </property>
                     <property name="layoutDirection">
-                     <enum>Qt::LayoutDirection::LeftToRight</enum>
+                     <enum>Qt::LeftToRight</enum>
                     </property>
                     <property name="frameShape">
-                     <enum>QFrame::Shape::NoFrame</enum>
-                    </property>
-                    <property name="frameShadow">
-                     <enum>QFrame::Shadow::Plain</enum>
+                     <enum>QFrame::NoFrame</enum>
                     </property>
                     <property name="text">
                      <string>Y</string>
                     </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
                    </widget>
                   </item>
-                  <item row="1" column="1" alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                  <item row="1" column="1">
                    <widget class="QLabel" name="mpos_x_l">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -2744,19 +2645,13 @@
                      </size>
                     </property>
                     <property name="layoutDirection">
-                     <enum>Qt::LayoutDirection::LeftToRight</enum>
+                     <enum>Qt::LeftToRight</enum>
                     </property>
                     <property name="frameShape">
-                     <enum>QFrame::Shape::NoFrame</enum>
-                    </property>
-                    <property name="frameShadow">
-                     <enum>QFrame::Shadow::Plain</enum>
+                     <enum>QFrame::NoFrame</enum>
                     </property>
                     <property name="text">
                      <string>0.0</string>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
                     </property>
                    </widget>
                   </item>
@@ -2765,7 +2660,7 @@
                 <item>
                  <widget class="Line" name="line">
                   <property name="orientation">
-                   <enum>Qt::Orientation::Horizontal</enum>
+                   <enum>Qt::Vertical</enum>
                   </property>
                  </widget>
                 </item>
@@ -4843,7 +4738,7 @@
              </size>
             </property>
             <property name="toolButtonStyle">
-             <enum>Qt::ToolButtonStyle::ToolButtonIconOnly</enum>
+             <enum>Qt::ToolButtonIconOnly</enum>
             </property>
            </widget>
           </item>
@@ -5023,15 +4918,6 @@
                  </color>
                 </brush>
                </colorrole>
-               <colorrole role="Accent">
-                <brush brushstyle="SolidPattern">
-                 <color alpha="255">
-                  <red>76</red>
-                  <green>194</green>
-                  <blue>255</blue>
-                 </color>
-                </brush>
-               </colorrole>
               </active>
               <inactive>
                <colorrole role="WindowText">
@@ -5184,15 +5070,6 @@
                   <red>0</red>
                   <green>0</green>
                   <blue>0</blue>
-                 </color>
-                </brush>
-               </colorrole>
-               <colorrole role="Accent">
-                <brush brushstyle="SolidPattern">
-                 <color alpha="255">
-                  <red>76</red>
-                  <green>194</green>
-                  <blue>255</blue>
                  </color>
                 </brush>
                </colorrole>
@@ -5351,15 +5228,6 @@
                  </color>
                 </brush>
                </colorrole>
-               <colorrole role="Accent">
-                <brush brushstyle="SolidPattern">
-                 <color alpha="255">
-                  <red>157</red>
-                  <green>157</green>
-                  <blue>157</blue>
-                 </color>
-                </brush>
-               </colorrole>
               </disabled>
              </palette>
             </property>
@@ -5371,16 +5239,10 @@
              </font>
             </property>
             <property name="frameShape">
-             <enum>QFrame::Shape::StyledPanel</enum>
-            </property>
-            <property name="frameShadow">
-             <enum>QFrame::Shadow::Plain</enum>
+             <enum>QFrame::NoFrame</enum>
             </property>
             <property name="text">
              <string>Not Connected</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignmentFlag::AlignCenter</set>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
@@ -5426,7 +5288,7 @@
              </size>
             </property>
             <property name="toolButtonStyle">
-             <enum>Qt::ToolButtonStyle::ToolButtonIconOnly</enum>
+             <enum>Qt::ToolButtonIconOnly</enum>
             </property>
            </widget>
           </item>
@@ -5469,7 +5331,7 @@
              </size>
             </property>
             <property name="toolButtonStyle">
-             <enum>Qt::ToolButtonStyle::ToolButtonIconOnly</enum>
+             <enum>Qt::ToolButtonIconOnly</enum>
             </property>
            </widget>
           </item>
@@ -5512,7 +5374,7 @@
              </size>
             </property>
             <property name="toolButtonStyle">
-             <enum>Qt::ToolButtonStyle::ToolButtonIconOnly</enum>
+             <enum>Qt::ToolButtonIconOnly</enum>
             </property>
            </widget>
           </item>
@@ -5555,7 +5417,7 @@
              </size>
             </property>
             <property name="toolButtonStyle">
-             <enum>Qt::ToolButtonStyle::ToolButtonIconOnly</enum>
+             <enum>Qt::ToolButtonIconOnly</enum>
             </property>
            </widget>
           </item>
@@ -5598,7 +5460,7 @@
              </size>
             </property>
             <property name="toolButtonStyle">
-             <enum>Qt::ToolButtonStyle::ToolButtonIconOnly</enum>
+             <enum>Qt::ToolButtonIconOnly</enum>
             </property>
            </widget>
           </item>
@@ -5641,7 +5503,7 @@
              </size>
             </property>
             <property name="toolButtonStyle">
-             <enum>Qt::ToolButtonStyle::ToolButtonIconOnly</enum>
+             <enum>Qt::ToolButtonIconOnly</enum>
             </property>
            </widget>
           </item>
@@ -5668,10 +5530,7 @@
               <item>
                <widget class="QFrame" name="frame">
                 <property name="frameShape">
-                 <enum>QFrame::Shape::StyledPanel</enum>
-                </property>
-                <property name="frameShadow">
-                 <enum>QFrame::Shadow::Raised</enum>
+                 <enum>QFrame::NoFrame</enum>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_13">
                  <item>
@@ -5701,7 +5560,7 @@
                  </item>
                  <item>
                   <layout class="QGridLayout" name="gridLayout_28">
-                   <item row="2" column="1" alignment="Qt::AlignmentFlag::AlignHCenter">
+                   <item row="2" column="1">
                     <widget class="QToolButton" name="tool_or_camera_tb">
                      <property name="text">
                       <string>TOOL POSITION</string>
@@ -5710,7 +5569,7 @@
                       <bool>true</bool>
                      </property>
                      <property name="toolButtonStyle">
-                      <enum>Qt::ToolButtonStyle::ToolButtonTextOnly</enum>
+                      <enum>Qt::ToolButtonIconOnly</enum>
                      </property>
                     </widget>
                    </item>
@@ -5748,9 +5607,6 @@
               </item>
               <item>
                <spacer name="verticalSpacer_3">
-                <property name="orientation">
-                 <enum>Qt::Orientation::Vertical</enum>
-                </property>
                 <property name="sizeHint" stdset="0">
                  <size>
                   <width>20</width>
@@ -5762,10 +5618,7 @@
               <item>
                <widget class="QFrame" name="frame_2">
                 <property name="frameShape">
-                 <enum>QFrame::Shape::StyledPanel</enum>
-                </property>
-                <property name="frameShadow">
-                 <enum>QFrame::Shadow::Plain</enum>
+                 <enum>QFrame::NoFrame</enum>
                 </property>
                 <property name="lineWidth">
                  <number>1</number>
@@ -5777,7 +5630,7 @@
                  <item>
                   <layout class="QGridLayout" name="gridLayoutDirections_2" rowstretch="0,0">
                    <property name="sizeConstraint">
-                    <enum>QLayout::SizeConstraint::SetFixedSize</enum>
+                    <enum>QLayout::SetDefaultConstraint</enum>
                    </property>
                    <property name="leftMargin">
                     <number>0</number>
@@ -5796,7 +5649,7 @@
                      <item row="2" column="0">
                       <layout class="QGridLayout" name="gridLayout_23">
                        <property name="sizeConstraint">
-                        <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+                        <enum>QLayout::SetDefaultConstraint</enum>
                        </property>
                        <item row="0" column="0">
                         <widget class="QPushButton" name="z_plus_pb_2">
@@ -6140,9 +5993,9 @@
                        <item>
                         <layout class="QHBoxLayout" name="horizontalLayout_26">
                          <property name="sizeConstraint">
-                          <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+                          <enum>QLayout::SetDefaultConstraint</enum>
                          </property>
-                         <item alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                         <item>
                           <widget class="QLabel" name="z_jog_l_4">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -6170,12 +6023,9 @@
                            <property name="text">
                             <string>Z step [mm]</string>
                            </property>
-                           <property name="alignment">
-                            <set>Qt::AlignmentFlag::AlignCenter</set>
-                           </property>
                           </widget>
                          </item>
-                         <item alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                         <item>
                           <widget class="QComboBox" name="z_step_cb_2">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -6268,11 +6118,8 @@
                              <bold>true</bold>
                             </font>
                            </property>
-                           <property name="alignment">
-                            <set>Qt::AlignmentFlag::AlignCenter</set>
-                           </property>
                            <property name="buttonSymbols">
-                            <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                            <enum>QAbstractSpinBox::UpDownArrows</enum>
                            </property>
                            <property name="minimum">
                             <double>0.010000000000000</double>
@@ -6430,9 +6277,9 @@
                        <item>
                         <layout class="QHBoxLayout" name="horizontalLayout_27">
                          <property name="sizeConstraint">
-                          <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+                          <enum>QLayout::SetDefaultConstraint</enum>
                          </property>
-                         <item alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                         <item>
                           <widget class="QLabel" name="xy_jog_l_2">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -6455,12 +6302,9 @@
                            <property name="text">
                             <string>XY step [mm]</string>
                            </property>
-                           <property name="alignment">
-                            <set>Qt::AlignmentFlag::AlignCenter</set>
-                           </property>
                           </widget>
                          </item>
-                         <item alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                         <item>
                           <widget class="QComboBox" name="xy_step_cb_2">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -6620,11 +6464,8 @@
                              <bold>true</bold>
                             </font>
                            </property>
-                           <property name="alignment">
-                            <set>Qt::AlignmentFlag::AlignCenter</set>
-                           </property>
                            <property name="buttonSymbols">
-                            <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                            <enum>QAbstractSpinBox::UpDownArrows</enum>
                            </property>
                            <property name="minimum">
                             <double>0.010000000000000</double>
@@ -6717,14 +6558,14 @@
                         <number>1</number>
                        </property>
                        <property name="orientation">
-                        <enum>Qt::Orientation::Horizontal</enum>
+                        <enum>Qt::Vertical</enum>
                        </property>
                       </widget>
                      </item>
                      <item row="1" column="0">
                       <widget class="Line" name="line_26">
                        <property name="orientation">
-                        <enum>Qt::Orientation::Horizontal</enum>
+                        <enum>Qt::Vertical</enum>
                        </property>
                       </widget>
                      </item>
@@ -6750,7 +6591,7 @@
                      <property name="verticalSpacing">
                       <number>2</number>
                      </property>
-                     <item row="0" column="3" alignment="Qt::AlignmentFlag::AlignHCenter">
+                     <item row="0" column="3">
                       <widget class="QLabel" name="z_axis_l_2">
                        <property name="sizePolicy">
                         <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -6776,23 +6617,17 @@
                         </font>
                        </property>
                        <property name="layoutDirection">
-                        <enum>Qt::LayoutDirection::LeftToRight</enum>
+                        <enum>Qt::LeftToRight</enum>
                        </property>
                        <property name="frameShape">
-                        <enum>QFrame::Shape::NoFrame</enum>
-                       </property>
-                       <property name="frameShadow">
-                        <enum>QFrame::Shadow::Plain</enum>
+                        <enum>QFrame::NoFrame</enum>
                        </property>
                        <property name="text">
                         <string>Z</string>
                        </property>
-                       <property name="alignment">
-                        <set>Qt::AlignmentFlag::AlignCenter</set>
-                       </property>
                       </widget>
                      </item>
-                     <item row="1" column="2" alignment="Qt::AlignmentFlag::AlignHCenter">
+                     <item row="1" column="2">
                       <widget class="QLabel" name="mpos_y_l_2">
                        <property name="sizePolicy">
                         <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -6813,23 +6648,17 @@
                         </size>
                        </property>
                        <property name="layoutDirection">
-                        <enum>Qt::LayoutDirection::LeftToRight</enum>
+                        <enum>Qt::LeftToRight</enum>
                        </property>
                        <property name="frameShape">
-                        <enum>QFrame::Shape::NoFrame</enum>
-                       </property>
-                       <property name="frameShadow">
-                        <enum>QFrame::Shadow::Plain</enum>
+                        <enum>QFrame::NoFrame</enum>
                        </property>
                        <property name="text">
                         <string>0.0</string>
                        </property>
-                       <property name="alignment">
-                        <set>Qt::AlignmentFlag::AlignCenter</set>
-                       </property>
                       </widget>
                      </item>
-                     <item row="0" column="1" alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                     <item row="0" column="1">
                       <widget class="QLabel" name="x_axis_l_2">
                        <property name="sizePolicy">
                         <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -6855,23 +6684,17 @@
                         </font>
                        </property>
                        <property name="layoutDirection">
-                        <enum>Qt::LayoutDirection::LeftToRight</enum>
+                        <enum>Qt::LeftToRight</enum>
                        </property>
                        <property name="frameShape">
-                        <enum>QFrame::Shape::NoFrame</enum>
-                       </property>
-                       <property name="frameShadow">
-                        <enum>QFrame::Shadow::Plain</enum>
+                        <enum>QFrame::NoFrame</enum>
                        </property>
                        <property name="text">
                         <string>X</string>
                        </property>
-                       <property name="alignment">
-                        <set>Qt::AlignmentFlag::AlignCenter</set>
-                       </property>
                       </widget>
                      </item>
-                     <item row="1" column="3" alignment="Qt::AlignmentFlag::AlignHCenter">
+                     <item row="1" column="3">
                       <widget class="QLabel" name="mpos_z_l_2">
                        <property name="sizePolicy">
                         <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -6892,23 +6715,17 @@
                         </size>
                        </property>
                        <property name="layoutDirection">
-                        <enum>Qt::LayoutDirection::LeftToRight</enum>
+                        <enum>Qt::LeftToRight</enum>
                        </property>
                        <property name="frameShape">
-                        <enum>QFrame::Shape::NoFrame</enum>
-                       </property>
-                       <property name="frameShadow">
-                        <enum>QFrame::Shadow::Plain</enum>
+                        <enum>QFrame::NoFrame</enum>
                        </property>
                        <property name="text">
                         <string>0.0</string>
                        </property>
-                       <property name="alignment">
-                        <set>Qt::AlignmentFlag::AlignCenter</set>
-                       </property>
                       </widget>
                      </item>
-                     <item row="1" column="1" alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                     <item row="1" column="1">
                       <widget class="QLabel" name="mpos_x_l_2">
                        <property name="sizePolicy">
                         <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -6929,23 +6746,17 @@
                         </size>
                        </property>
                        <property name="layoutDirection">
-                        <enum>Qt::LayoutDirection::LeftToRight</enum>
+                        <enum>Qt::LeftToRight</enum>
                        </property>
                        <property name="frameShape">
-                        <enum>QFrame::Shape::NoFrame</enum>
-                       </property>
-                       <property name="frameShadow">
-                        <enum>QFrame::Shadow::Plain</enum>
+                        <enum>QFrame::NoFrame</enum>
                        </property>
                        <property name="text">
                         <string>0.0</string>
                        </property>
-                       <property name="alignment">
-                        <set>Qt::AlignmentFlag::AlignCenter</set>
-                       </property>
                       </widget>
                      </item>
-                     <item row="2" column="0" alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                     <item row="2" column="0">
                       <widget class="QLabel" name="wpos_l_2">
                        <property name="sizePolicy">
                         <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -6971,23 +6782,17 @@
                         </font>
                        </property>
                        <property name="layoutDirection">
-                        <enum>Qt::LayoutDirection::LeftToRight</enum>
+                        <enum>Qt::LeftToRight</enum>
                        </property>
                        <property name="frameShape">
-                        <enum>QFrame::Shape::NoFrame</enum>
-                       </property>
-                       <property name="frameShadow">
-                        <enum>QFrame::Shadow::Plain</enum>
+                        <enum>QFrame::NoFrame</enum>
                        </property>
                        <property name="text">
                         <string>WPos</string>
                        </property>
-                       <property name="alignment">
-                        <set>Qt::AlignmentFlag::AlignCenter</set>
-                       </property>
                       </widget>
                      </item>
-                     <item row="2" column="1" alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                     <item row="2" column="1">
                       <widget class="QLabel" name="wpos_x_l_2">
                        <property name="sizePolicy">
                         <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -7008,23 +6813,17 @@
                         </size>
                        </property>
                        <property name="layoutDirection">
-                        <enum>Qt::LayoutDirection::LeftToRight</enum>
+                        <enum>Qt::LeftToRight</enum>
                        </property>
                        <property name="frameShape">
-                        <enum>QFrame::Shape::NoFrame</enum>
-                       </property>
-                       <property name="frameShadow">
-                        <enum>QFrame::Shadow::Plain</enum>
+                        <enum>QFrame::NoFrame</enum>
                        </property>
                        <property name="text">
                         <string>0.0</string>
                        </property>
-                       <property name="alignment">
-                        <set>Qt::AlignmentFlag::AlignCenter</set>
-                       </property>
                       </widget>
                      </item>
-                     <item row="1" column="0" alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                     <item row="1" column="0">
                       <widget class="QLabel" name="mpos_l_2">
                        <property name="sizePolicy">
                         <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -7050,23 +6849,17 @@
                         </font>
                        </property>
                        <property name="layoutDirection">
-                        <enum>Qt::LayoutDirection::LeftToRight</enum>
+                        <enum>Qt::LeftToRight</enum>
                        </property>
                        <property name="frameShape">
-                        <enum>QFrame::Shape::NoFrame</enum>
-                       </property>
-                       <property name="frameShadow">
-                        <enum>QFrame::Shadow::Plain</enum>
+                        <enum>QFrame::NoFrame</enum>
                        </property>
                        <property name="text">
                         <string>MPos</string>
                        </property>
-                       <property name="alignment">
-                        <set>Qt::AlignmentFlag::AlignCenter</set>
-                       </property>
                       </widget>
                      </item>
-                     <item row="2" column="3" alignment="Qt::AlignmentFlag::AlignHCenter">
+                     <item row="2" column="3">
                       <widget class="QLabel" name="wpos_z_l_2">
                        <property name="sizePolicy">
                         <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -7087,23 +6880,17 @@
                         </size>
                        </property>
                        <property name="layoutDirection">
-                        <enum>Qt::LayoutDirection::LeftToRight</enum>
+                        <enum>Qt::LeftToRight</enum>
                        </property>
                        <property name="frameShape">
-                        <enum>QFrame::Shape::NoFrame</enum>
-                       </property>
-                       <property name="frameShadow">
-                        <enum>QFrame::Shadow::Plain</enum>
+                        <enum>QFrame::NoFrame</enum>
                        </property>
                        <property name="text">
                         <string>0.0</string>
                        </property>
-                       <property name="alignment">
-                        <set>Qt::AlignmentFlag::AlignCenter</set>
-                       </property>
                       </widget>
                      </item>
-                     <item row="0" column="0" alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                     <item row="0" column="0">
                       <widget class="QLabel" name="axis_l_2">
                        <property name="sizePolicy">
                         <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -7129,23 +6916,17 @@
                         </font>
                        </property>
                        <property name="layoutDirection">
-                        <enum>Qt::LayoutDirection::LeftToRight</enum>
+                        <enum>Qt::LeftToRight</enum>
                        </property>
                        <property name="frameShape">
-                        <enum>QFrame::Shape::NoFrame</enum>
-                       </property>
-                       <property name="frameShadow">
-                        <enum>QFrame::Shadow::Plain</enum>
+                        <enum>QFrame::NoFrame</enum>
                        </property>
                        <property name="text">
                         <string>Axis:</string>
                        </property>
-                       <property name="alignment">
-                        <set>Qt::AlignmentFlag::AlignCenter</set>
-                       </property>
                       </widget>
                      </item>
-                     <item row="0" column="2" alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                     <item row="0" column="2">
                       <widget class="QLabel" name="y_axis_l_2">
                        <property name="sizePolicy">
                         <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -7171,23 +6952,17 @@
                         </font>
                        </property>
                        <property name="layoutDirection">
-                        <enum>Qt::LayoutDirection::LeftToRight</enum>
+                        <enum>Qt::LeftToRight</enum>
                        </property>
                        <property name="frameShape">
-                        <enum>QFrame::Shape::NoFrame</enum>
-                       </property>
-                       <property name="frameShadow">
-                        <enum>QFrame::Shadow::Plain</enum>
+                        <enum>QFrame::NoFrame</enum>
                        </property>
                        <property name="text">
                         <string>Y</string>
                        </property>
-                       <property name="alignment">
-                        <set>Qt::AlignmentFlag::AlignCenter</set>
-                       </property>
                       </widget>
                      </item>
-                     <item row="2" column="2" alignment="Qt::AlignmentFlag::AlignHCenter">
+                     <item row="2" column="2">
                       <widget class="QLabel" name="wpos_y_l_2">
                        <property name="sizePolicy">
                         <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
@@ -7208,19 +6983,13 @@
                         </size>
                        </property>
                        <property name="layoutDirection">
-                        <enum>Qt::LayoutDirection::LeftToRight</enum>
+                        <enum>Qt::LeftToRight</enum>
                        </property>
                        <property name="frameShape">
-                        <enum>QFrame::Shape::NoFrame</enum>
-                       </property>
-                       <property name="frameShadow">
-                        <enum>QFrame::Shadow::Plain</enum>
+                        <enum>QFrame::NoFrame</enum>
                        </property>
                        <property name="text">
                         <string>0.0</string>
-                       </property>
-                       <property name="alignment">
-                        <set>Qt::AlignmentFlag::AlignCenter</set>
                        </property>
                       </widget>
                      </item>
@@ -7233,11 +7002,8 @@
               </item>
               <item>
                <spacer name="verticalSpacer_9">
-                <property name="orientation">
-                 <enum>Qt::Orientation::Vertical</enum>
-                </property>
                 <property name="sizeType">
-                 <enum>QSizePolicy::Policy::Fixed</enum>
+                 <enum>QSizePolicy::Fixed</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -7277,7 +7043,7 @@
                    <bool>true</bool>
                   </property>
                   <property name="toolButtonStyle">
-                   <enum>Qt::ToolButtonStyle::ToolButtonTextOnly</enum>
+                   <enum>Qt::ToolButtonIconOnly</enum>
                   </property>
                  </widget>
                 </item>
@@ -7302,15 +7068,12 @@
                    <bool>true</bool>
                   </property>
                   <property name="toolButtonStyle">
-                   <enum>Qt::ToolButtonStyle::ToolButtonTextOnly</enum>
+                   <enum>Qt::ToolButtonIconOnly</enum>
                   </property>
                  </widget>
                 </item>
                 <item>
                  <spacer name="horizontalSpacer_14">
-                  <property name="orientation">
-                   <enum>Qt::Orientation::Horizontal</enum>
-                  </property>
                   <property name="sizeHint" stdset="0">
                    <size>
                     <width>40</width>
@@ -7346,7 +7109,7 @@
              <layout class="QVBoxLayout" name="verticalLayout_21">
               <item>
                <layout class="QVBoxLayout" name="verticalLayout_22">
-                <item alignment="Qt::AlignmentFlag::AlignHCenter">
+                <item>
                  <widget class="QTableWidget" name="align_points_tw">
                   <property name="sizePolicy">
                    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -7367,7 +7130,7 @@
                    </size>
                   </property>
                   <property name="sizeAdjustPolicy">
-                   <enum>QAbstractScrollArea::SizeAdjustPolicy::AdjustToContents</enum>
+                   <enum>QAbstractScrollArea::AdjustIgnored</enum>
                   </property>
                   <property name="columnCount">
                    <number>4</number>
@@ -7411,7 +7174,7 @@
                       <normaloff>:/resources/resources/icons/gray-refresh.svg</normaloff>:/resources/resources/icons/gray-refresh.svg</iconset>
                     </property>
                     <property name="toolButtonStyle">
-                     <enum>Qt::ToolButtonStyle::ToolButtonTextOnly</enum>
+                     <enum>Qt::ToolButtonIconOnly</enum>
                     </property>
                    </widget>
                   </item>
@@ -7445,15 +7208,12 @@
                      <string>Ctrl+G</string>
                     </property>
                     <property name="toolButtonStyle">
-                     <enum>Qt::ToolButtonStyle::ToolButtonTextOnly</enum>
+                     <enum>Qt::ToolButtonIconOnly</enum>
                     </property>
                    </widget>
                   </item>
                   <item>
                    <spacer name="horizontalSpacer_13">
-                    <property name="orientation">
-                     <enum>Qt::Orientation::Horizontal</enum>
-                    </property>
                     <property name="sizeHint" stdset="0">
                      <size>
                       <width>40</width>
@@ -7488,7 +7248,7 @@
                      <bool>true</bool>
                     </property>
                     <property name="toolButtonStyle">
-                     <enum>Qt::ToolButtonStyle::ToolButtonIconOnly</enum>
+                     <enum>Qt::ToolButtonIconOnly</enum>
                     </property>
                    </widget>
                   </item>
@@ -7498,7 +7258,7 @@
               </item>
               <item>
                <layout class="QHBoxLayout" name="horizontalLayout_30" stretch="0,0,0">
-                <item alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                <item>
                  <widget class="QLabel" name="label_17">
                   <property name="sizePolicy">
                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -7521,16 +7281,10 @@
                   <property name="text">
                    <string>Error/STD_Deviation</string>
                   </property>
-                  <property name="alignment">
-                   <set>Qt::AlignmentFlag::AlignCenter</set>
-                  </property>
                  </widget>
                 </item>
                 <item>
                  <spacer name="horizontalSpacer_15">
-                  <property name="orientation">
-                   <enum>Qt::Orientation::Horizontal</enum>
-                  </property>
                   <property name="sizeHint" stdset="0">
                    <size>
                     <width>40</width>
@@ -7539,7 +7293,7 @@
                   </property>
                  </spacer>
                 </item>
-                <item alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+                <item>
                  <widget class="QLabel" name="label_18">
                   <property name="sizePolicy">
                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -7561,9 +7315,6 @@
                   </property>
                   <property name="text">
                    <string>No value available</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignmentFlag::AlignCenter</set>
                   </property>
                  </widget>
                 </item>
@@ -7588,14 +7339,217 @@
            <bool>true</bool>
           </property>
           <property name="currentIndex">
-           <number>2</number>
+           <number>0</number>
           </property>
           <widget class="QWidget" name="application_settings_tab">
            <attribute name="title">
             <string>Application Settings</string>
            </attribute>
            <layout class="QGridLayout" name="gridLayout_9">
-            <item row="3" column="0">
+            <item row="5" column="0">
+             <spacer name="verticalSpacer_12">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>10</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="1" column="1" rowspan="2">
+             <spacer name="horizontalSpacer_3">
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="7" column="0">
+             <layout class="QGridLayout" name="gridLayout_10">
+              <item row="0" column="0">
+               <widget class="QLabel" name="allignment_drill_diameter_la_2">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>200</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>130</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="locale">
+                 <locale language="English" country="UnitedKingdom"/>
+                </property>
+                <property name="text">
+                 <string>Serial Error Warning Threshold</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QSpinBox" name="serial_error_warning_threshold_sb">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>252</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>252</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="locale">
+                 <locale language="English" country="UnitedKingdom"/>
+                </property>
+                <property name="buttonSymbols">
+                 <enum>QAbstractSpinBox::UpDownArrows</enum>
+                </property>
+                <property name="value">
+                 <number>3</number>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="allignment_drill_diameter_la_3">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>200</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>130</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="locale">
+                 <locale language="English" country="UnitedKingdom"/>
+                </property>
+                <property name="text">
+                 <string>Serial Error Critical Threshold</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QSpinBox" name="serial_error_critical_threshold_sb">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>252</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>252</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="locale">
+                 <locale language="English" country="UnitedKingdom"/>
+                </property>
+                <property name="buttonSymbols">
+                 <enum>QAbstractSpinBox::UpDownArrows</enum>
+                </property>
+                <property name="value">
+                 <number>10</number>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="layer_colors_section_la">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>210</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>300</width>
+                <height>20</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>12</pointsize>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string>LAYER COLORS</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0">
+             <widget class="Line" name="line_17">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
              <layout class="QGridLayout" name="gridLayout_12">
               <item row="0" column="0">
                <widget class="QPushButton" name="top_layer_color_pb">
@@ -7620,7 +7574,7 @@
                  </size>
                 </property>
                 <property name="frameShape">
-                 <enum>QFrame::Shape::WinPanel</enum>
+                 <enum>QFrame::NoFrame</enum>
                 </property>
                 <property name="text">
                  <string/>
@@ -7650,7 +7604,7 @@
                  </size>
                 </property>
                 <property name="frameShape">
-                 <enum>QFrame::Shape::WinPanel</enum>
+                 <enum>QFrame::NoFrame</enum>
                 </property>
                 <property name="text">
                  <string/>
@@ -7680,7 +7634,7 @@
                  </size>
                 </property>
                 <property name="frameShape">
-                 <enum>QFrame::Shape::WinPanel</enum>
+                 <enum>QFrame::NoFrame</enum>
                 </property>
                 <property name="text">
                  <string/>
@@ -7696,7 +7650,7 @@
                  </size>
                 </property>
                 <property name="frameShape">
-                 <enum>QFrame::Shape::WinPanel</enum>
+                 <enum>QFrame::NoFrame</enum>
                 </property>
                 <property name="text">
                  <string/>
@@ -7712,7 +7666,7 @@
                  </size>
                 </property>
                 <property name="frameShape">
-                 <enum>QFrame::Shape::WinPanel</enum>
+                 <enum>QFrame::NoFrame</enum>
                 </property>
                 <property name="text">
                  <string/>
@@ -7728,7 +7682,7 @@
                  </size>
                 </property>
                 <property name="frameShape">
-                 <enum>QFrame::Shape::WinPanel</enum>
+                 <enum>QFrame::NoFrame</enum>
                 </property>
                 <property name="text">
                  <string/>
@@ -7737,28 +7691,8 @@
               </item>
              </layout>
             </item>
-            <item row="2" column="0">
-             <widget class="Line" name="line_17">
-              <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="0">
-             <spacer name="verticalSpacer_2">
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="layer_colors_section_la">
+            <item row="6" column="0">
+             <widget class="QLabel" name="layer_colors_section_la_2">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -7784,32 +7718,32 @@
                </font>
               </property>
               <property name="text">
-               <string>LAYER COLORS</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignmentFlag::AlignCenter</set>
+               <string>SERIAL SETTINGS</string>
               </property>
              </widget>
             </item>
-            <item row="3" column="1">
-             <spacer name="horizontalSpacer_3">
-              <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
-              </property>
+            <item row="8" column="0">
+             <spacer name="verticalSpacer_2">
               <property name="sizeHint" stdset="0">
                <size>
-                <width>40</width>
-                <height>20</height>
+                <width>20</width>
+                <height>40</height>
                </size>
               </property>
              </spacer>
             </item>
-            <item row="0" column="0">
-             <widget class="Line" name="line_18">
+            <item row="3" column="0">
+             <spacer name="verticalSpacer_13">
               <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
+               <enum>Qt::Vertical</enum>
               </property>
-             </widget>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
             </item>
            </layout>
           </widget>
@@ -7821,9 +7755,9 @@
             <item row="3" column="0">
              <layout class="QGridLayout" name="gridLayout_20">
               <property name="sizeConstraint">
-               <enum>QLayout::SizeConstraint::SetFixedSize</enum>
+               <enum>QLayout::SetDefaultConstraint</enum>
               </property>
-              <item row="0" column="1" alignment="Qt::AlignmentFlag::AlignHCenter">
+              <item row="0" column="1">
                <widget class="QLabel" name="x_axis_la">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -7856,7 +7790,7 @@
                 </property>
                </widget>
               </item>
-              <item row="0" column="2" alignment="Qt::AlignmentFlag::AlignHCenter">
+              <item row="0" column="2">
                <widget class="QLabel" name="x_la_2">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -7889,7 +7823,7 @@
                 </property>
                </widget>
               </item>
-              <item row="1" column="0" alignment="Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter">
+              <item row="1" column="0">
                <widget class="QLabel" name="mirroring_axis_la">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -7922,7 +7856,7 @@
                 </property>
                </widget>
               </item>
-              <item row="1" column="1" alignment="Qt::AlignmentFlag::AlignHCenter">
+              <item row="1" column="1">
                <widget class="QRadioButton" name="x_mirror_rb">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -7941,7 +7875,7 @@
                 </property>
                </widget>
               </item>
-              <item row="1" column="2" alignment="Qt::AlignmentFlag::AlignHCenter">
+              <item row="1" column="2">
                <widget class="QRadioButton" name="y_mirror_rb">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -7962,11 +7896,8 @@
               </item>
               <item row="0" column="0">
                <spacer name="horizontalSpacer_9">
-                <property name="orientation">
-                 <enum>Qt::Orientation::Horizontal</enum>
-                </property>
                 <property name="sizeType">
-                 <enum>QSizePolicy::Policy::Fixed</enum>
+                 <enum>QSizePolicy::Fixed</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -7978,7 +7909,7 @@
               </item>
              </layout>
             </item>
-            <item row="7" column="0" alignment="Qt::AlignmentFlag::AlignHCenter">
+            <item row="7" column="0">
              <widget class="QLabel" name="probe_settings_section_la">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -7999,11 +7930,8 @@
             </item>
             <item row="10" column="0">
              <spacer name="verticalSpacer_6">
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
-              </property>
               <property name="sizeType">
-               <enum>QSizePolicy::Policy::Expanding</enum>
+               <enum>QSizePolicy::Fixed</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -8015,9 +7943,6 @@
             </item>
             <item row="21" column="0">
              <spacer name="verticalSpacer_8">
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
-              </property>
               <property name="sizeHint" stdset="0">
                <size>
                 <width>20</width>
@@ -8029,11 +7954,11 @@
             <item row="19" column="0">
              <widget class="Line" name="line_10">
               <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
+               <enum>Qt::Vertical</enum>
               </property>
              </widget>
             </item>
-            <item row="12" column="0" alignment="Qt::AlignmentFlag::AlignHCenter">
+            <item row="12" column="0">
              <widget class="QLabel" name="tool_change_section_la">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -8054,9 +7979,6 @@
             </item>
             <item row="5" column="0">
              <spacer name="verticalSpacer_5">
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
-              </property>
               <property name="sizeHint" stdset="0">
                <size>
                 <width>20</width>
@@ -8065,7 +7987,7 @@
               </property>
              </spacer>
             </item>
-            <item row="1" column="0" alignment="Qt::AlignmentFlag::AlignHCenter">
+            <item row="1" column="0">
              <widget class="QLabel" name="jobs_common_settings_section_la">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -8099,17 +8021,14 @@
             <item row="6" column="0">
              <widget class="Line" name="line_16">
               <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
+               <enum>Qt::Vertical</enum>
               </property>
              </widget>
             </item>
             <item row="14" column="1">
              <spacer name="horizontalSpacer_4">
-              <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
-              </property>
               <property name="sizeType">
-               <enum>QSizePolicy::Policy::Expanding</enum>
+               <enum>QSizePolicy::Fixed</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -8146,11 +8065,8 @@
                 <property name="locale">
                  <locale language="English" country="UnitedKingdom"/>
                 </property>
-                <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignCenter</set>
-                </property>
                 <property name="buttonSymbols">
-                 <enum>QAbstractSpinBox::ButtonSymbols::UpDownArrows</enum>
+                 <enum>QAbstractSpinBox::UpDownArrows</enum>
                 </property>
                 <property name="maximum">
                  <double>100000.000000000000000</double>
@@ -8254,11 +8170,8 @@
                 <property name="locale">
                  <locale language="English" country="UnitedKingdom"/>
                 </property>
-                <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignCenter</set>
-                </property>
                 <property name="buttonSymbols">
-                 <enum>QAbstractSpinBox::ButtonSymbols::UpDownArrows</enum>
+                 <enum>QAbstractSpinBox::UpDownArrows</enum>
                 </property>
                 <property name="maximum">
                  <double>100000.000000000000000</double>
@@ -8290,11 +8203,8 @@
                 <property name="locale">
                  <locale language="English" country="UnitedKingdom"/>
                 </property>
-                <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignCenter</set>
-                </property>
                 <property name="buttonSymbols">
-                 <enum>QAbstractSpinBox::ButtonSymbols::UpDownArrows</enum>
+                 <enum>QAbstractSpinBox::UpDownArrows</enum>
                 </property>
                 <property name="maximum">
                  <double>100000.000000000000000</double>
@@ -8339,11 +8249,8 @@
               </item>
               <item row="0" column="2">
                <spacer name="horizontalSpacer_6">
-                <property name="orientation">
-                 <enum>Qt::Orientation::Horizontal</enum>
-                </property>
                 <property name="sizeType">
-                 <enum>QSizePolicy::Policy::Fixed</enum>
+                 <enum>QSizePolicy::Fixed</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -8355,11 +8262,8 @@
               </item>
               <item row="1" column="2">
                <spacer name="horizontalSpacer_7">
-                <property name="orientation">
-                 <enum>Qt::Orientation::Horizontal</enum>
-                </property>
                 <property name="sizeType">
-                 <enum>QSizePolicy::Policy::Fixed</enum>
+                 <enum>QSizePolicy::Fixed</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -8371,11 +8275,8 @@
               </item>
               <item row="2" column="2">
                <spacer name="horizontalSpacer_8">
-                <property name="orientation">
-                 <enum>Qt::Orientation::Horizontal</enum>
-                </property>
                 <property name="sizeType">
-                 <enum>QSizePolicy::Policy::Fixed</enum>
+                 <enum>QSizePolicy::Fixed</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -8393,14 +8294,14 @@
                <number>2</number>
               </property>
               <property name="sizeConstraint">
-               <enum>QLayout::SizeConstraint::SetFixedSize</enum>
+               <enum>QLayout::SetDefaultConstraint</enum>
               </property>
               <item>
                <layout class="QHBoxLayout" name="horizontalLayout_13">
                 <item>
                  <layout class="QGridLayout" name="gridLayout_14">
                   <property name="sizeConstraint">
-                   <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+                   <enum>QLayout::SetDefaultConstraint</enum>
                   </property>
                   <property name="verticalSpacing">
                    <number>2</number>
@@ -8430,11 +8331,8 @@
                       <bold>true</bold>
                      </font>
                     </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
                     <property name="buttonSymbols">
-                     <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                     <enum>QAbstractSpinBox::UpDownArrows</enum>
                     </property>
                     <property name="minimum">
                      <double>-1000.000000000000000</double>
@@ -8472,11 +8370,8 @@
                       <bold>true</bold>
                      </font>
                     </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
                     <property name="buttonSymbols">
-                     <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                     <enum>QAbstractSpinBox::UpDownArrows</enum>
                     </property>
                     <property name="minimum">
                      <double>-1000.000000000000000</double>
@@ -8489,7 +8384,7 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="0" column="1" alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <item row="0" column="1">
                    <widget class="QLabel" name="x_la">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -8516,7 +8411,7 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="0" column="2" alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <item row="0" column="2">
                    <widget class="QLabel" name="y_la">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -8571,11 +8466,8 @@
                     <property name="locale">
                      <locale language="English" country="UnitedKingdom"/>
                     </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
                     <property name="buttonSymbols">
-                     <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                     <enum>QAbstractSpinBox::UpDownArrows</enum>
                     </property>
                     <property name="minimum">
                      <double>-1000.000000000000000</double>
@@ -8613,11 +8505,8 @@
                       <bold>true</bold>
                      </font>
                     </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
                     <property name="buttonSymbols">
-                     <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                     <enum>QAbstractSpinBox::UpDownArrows</enum>
                     </property>
                     <property name="minimum">
                      <double>-1000.000000000000000</double>
@@ -8630,7 +8519,7 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="0" column="3" alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <item row="0" column="3">
                    <widget class="QLabel" name="z_la">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -8682,11 +8571,8 @@
                       <bold>true</bold>
                      </font>
                     </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
                     <property name="buttonSymbols">
-                     <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                     <enum>QAbstractSpinBox::UpDownArrows</enum>
                     </property>
                     <property name="minimum">
                      <double>-1000.000000000000000</double>
@@ -8757,11 +8643,8 @@
                       <bold>true</bold>
                      </font>
                     </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
                     <property name="buttonSymbols">
-                     <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                     <enum>QAbstractSpinBox::UpDownArrows</enum>
                     </property>
                     <property name="minimum">
                      <double>-1000.000000000000000</double>
@@ -8832,11 +8715,8 @@
                       <bold>true</bold>
                      </font>
                     </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
                     <property name="buttonSymbols">
-                     <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                     <enum>QAbstractSpinBox::UpDownArrows</enum>
                     </property>
                     <property name="minimum">
                      <double>-1000.000000000000000</double>
@@ -8882,7 +8762,7 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="1" column="4" alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <item row="1" column="4">
                    <widget class="QCheckBox" name="tool_probe_wm_pos_chb">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -8903,7 +8783,7 @@
                      </size>
                     </property>
                     <property name="layoutDirection">
-                     <enum>Qt::LayoutDirection::LeftToRight</enum>
+                     <enum>Qt::LeftToRight</enum>
                     </property>
                     <property name="autoFillBackground">
                      <bool>true</bool>
@@ -8913,7 +8793,7 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="2" column="4" alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <item row="2" column="4">
                    <widget class="QPushButton" name="get_tool_probe_pb">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -8953,7 +8833,7 @@
               <item>
                <widget class="Line" name="line_6">
                 <property name="orientation">
-                 <enum>Qt::Orientation::Horizontal</enum>
+                 <enum>Qt::Vertical</enum>
                 </property>
                </widget>
               </item>
@@ -8962,7 +8842,7 @@
                 <item>
                  <layout class="QGridLayout" name="gridLayout_15">
                   <property name="sizeConstraint">
-                   <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+                   <enum>QLayout::SetDefaultConstraint</enum>
                   </property>
                   <item row="0" column="4">
                    <widget class="QDoubleSpinBox" name="tool_change_z_mpos_dsb">
@@ -8992,11 +8872,8 @@
                     <property name="locale">
                      <locale language="English" country="UnitedKingdom"/>
                     </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
                     <property name="buttonSymbols">
-                     <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                     <enum>QAbstractSpinBox::UpDownArrows</enum>
                     </property>
                     <property name="minimum">
                      <double>-1000.000000000000000</double>
@@ -9037,11 +8914,8 @@
                     <property name="locale">
                      <locale language="English" country="UnitedKingdom"/>
                     </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
                     <property name="buttonSymbols">
-                     <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                     <enum>QAbstractSpinBox::UpDownArrows</enum>
                     </property>
                     <property name="minimum">
                      <double>-1000.000000000000000</double>
@@ -9082,11 +8956,8 @@
                     <property name="locale">
                      <locale language="English" country="UnitedKingdom"/>
                     </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignCenter</set>
-                    </property>
                     <property name="buttonSymbols">
-                     <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                     <enum>QAbstractSpinBox::UpDownArrows</enum>
                     </property>
                     <property name="minimum">
                      <double>-1000.000000000000000</double>
@@ -9132,7 +9003,7 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="0" column="5" alignment="Qt::AlignmentFlag::AlignHCenter">
+                  <item row="0" column="5">
                    <widget class="QPushButton" name="get_tool_change_pb">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -9174,36 +9045,33 @@
             <item row="13" column="0">
              <widget class="Line" name="line_8">
               <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
+               <enum>Qt::Vertical</enum>
               </property>
              </widget>
             </item>
             <item row="8" column="0">
              <widget class="Line" name="line_15">
               <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
+               <enum>Qt::Vertical</enum>
               </property>
              </widget>
             </item>
             <item row="17" column="0">
              <widget class="Line" name="line_9">
               <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
+               <enum>Qt::Vertical</enum>
               </property>
              </widget>
             </item>
             <item row="15" column="0">
              <widget class="Line" name="line_7">
               <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
+               <enum>Qt::Vertical</enum>
               </property>
              </widget>
             </item>
             <item row="16" column="0">
              <spacer name="verticalSpacer_4">
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
-              </property>
               <property name="sizeHint" stdset="0">
                <size>
                 <width>20</width>
@@ -9215,7 +9083,7 @@
             <item row="0" column="0">
              <widget class="Line" name="line_12">
               <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
+               <enum>Qt::Vertical</enum>
               </property>
              </widget>
             </item>
@@ -9225,7 +9093,7 @@
                <number>2</number>
               </property>
               <property name="sizeConstraint">
-               <enum>QLayout::SizeConstraint::SetFixedSize</enum>
+               <enum>QLayout::SetDefaultConstraint</enum>
               </property>
               <item>
                <layout class="QGridLayout" name="gridLayout_21">
@@ -9237,11 +9105,8 @@
                 </property>
                 <item row="0" column="0">
                  <spacer name="horizontalSpacer_10">
-                  <property name="orientation">
-                   <enum>Qt::Orientation::Horizontal</enum>
-                  </property>
                   <property name="sizeType">
-                   <enum>QSizePolicy::Policy::Fixed</enum>
+                   <enum>QSizePolicy::Fixed</enum>
                   </property>
                   <property name="sizeHint" stdset="0">
                    <size>
@@ -9251,7 +9116,7 @@
                   </property>
                  </spacer>
                 </item>
-                <item row="0" column="1" alignment="Qt::AlignmentFlag::AlignHCenter">
+                <item row="0" column="1">
                  <widget class="QCheckBox" name="hold_on_probe_chb">
                   <property name="sizePolicy">
                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -9276,7 +9141,7 @@
                   </property>
                  </widget>
                 </item>
-                <item row="0" column="2" alignment="Qt::AlignmentFlag::AlignHCenter">
+                <item row="0" column="2">
                  <widget class="QCheckBox" name="zeroing_after_probe_chb">
                   <property name="sizePolicy">
                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -9305,7 +9170,7 @@
               </item>
              </layout>
             </item>
-            <item row="18" column="0" alignment="Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignVCenter">
+            <item row="18" column="0">
              <widget class="QLabel" name="feedrates_section_la">
               <property name="font">
                <font>
@@ -9321,21 +9186,21 @@
             <item row="2" column="0">
              <widget class="Line" name="line_11">
               <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
+               <enum>Qt::Vertical</enum>
               </property>
              </widget>
             </item>
             <item row="4" column="0">
              <widget class="Line" name="line_13">
               <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
+               <enum>Qt::Vertical</enum>
               </property>
              </widget>
             </item>
             <item row="11" column="0">
              <widget class="Line" name="line_14">
               <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
+               <enum>Qt::Vertical</enum>
               </property>
              </widget>
             </item>
@@ -9351,11 +9216,11 @@
               <item>
                <widget class="Line" name="line_21">
                 <property name="orientation">
-                 <enum>Qt::Orientation::Horizontal</enum>
+                 <enum>Qt::Vertical</enum>
                 </property>
                </widget>
               </item>
-              <item alignment="Qt::AlignmentFlag::AlignHCenter">
+              <item>
                <widget class="QLabel" name="alignment_drill_section_la">
                 <property name="font">
                  <font>
@@ -9371,7 +9236,7 @@
               <item>
                <widget class="Line" name="line_22">
                 <property name="orientation">
-                 <enum>Qt::Orientation::Horizontal</enum>
+                 <enum>Qt::Vertical</enum>
                 </property>
                </widget>
               </item>
@@ -9438,11 +9303,8 @@
                   <property name="locale">
                    <locale language="English" country="UnitedKingdom"/>
                   </property>
-                  <property name="alignment">
-                   <set>Qt::AlignmentFlag::AlignCenter</set>
-                  </property>
                   <property name="buttonSymbols">
-                   <enum>QAbstractSpinBox::ButtonSymbols::UpDownArrows</enum>
+                   <enum>QAbstractSpinBox::UpDownArrows</enum>
                   </property>
                   <property name="maximum">
                    <double>100000.000000000000000</double>
@@ -9456,9 +9318,6 @@
               </item>
               <item>
                <spacer name="verticalSpacer_10">
-                <property name="orientation">
-                 <enum>Qt::Orientation::Vertical</enum>
-                </property>
                 <property name="sizeHint" stdset="0">
                  <size>
                   <width>20</width>
@@ -9470,11 +9329,11 @@
               <item>
                <widget class="Line" name="line_23">
                 <property name="orientation">
-                 <enum>Qt::Orientation::Horizontal</enum>
+                 <enum>Qt::Vertical</enum>
                 </property>
                </widget>
               </item>
-              <item alignment="Qt::AlignmentFlag::AlignHCenter">
+              <item>
                <widget class="QLabel" name="alignment_camera_tool_offset_section_la">
                 <property name="font">
                  <font>
@@ -9490,14 +9349,14 @@
               <item>
                <widget class="Line" name="line_24">
                 <property name="orientation">
-                 <enum>Qt::Orientation::Horizontal</enum>
+                 <enum>Qt::Vertical</enum>
                 </property>
                </widget>
               </item>
               <item>
                <layout class="QGridLayout" name="gridLayout_17">
                 <property name="sizeConstraint">
-                 <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+                 <enum>QLayout::SetDefaultConstraint</enum>
                 </property>
                 <item row="0" column="0">
                  <widget class="QLabel" name="tool_camera_offset_la">
@@ -9560,11 +9419,8 @@
                   <property name="locale">
                    <locale language="English" country="UnitedKingdom"/>
                   </property>
-                  <property name="alignment">
-                   <set>Qt::AlignmentFlag::AlignCenter</set>
-                  </property>
                   <property name="buttonSymbols">
-                   <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                   <enum>QAbstractSpinBox::UpDownArrows</enum>
                   </property>
                   <property name="minimum">
                    <double>-1000.000000000000000</double>
@@ -9577,7 +9433,7 @@
                   </property>
                  </widget>
                 </item>
-                <item row="0" column="4" alignment="Qt::AlignmentFlag::AlignHCenter">
+                <item row="0" column="4">
                  <widget class="QPushButton" name="get_tool_camera_offset_pb">
                   <property name="sizePolicy">
                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -9638,11 +9494,8 @@
                   <property name="locale">
                    <locale language="English" country="UnitedKingdom"/>
                   </property>
-                  <property name="alignment">
-                   <set>Qt::AlignmentFlag::AlignCenter</set>
-                  </property>
                   <property name="buttonSymbols">
-                   <enum>QAbstractSpinBox::ButtonSymbols::NoButtons</enum>
+                   <enum>QAbstractSpinBox::UpDownArrows</enum>
                   </property>
                   <property name="minimum">
                    <double>-1000.000000000000000</double>
@@ -9659,9 +9512,6 @@
               </item>
               <item>
                <spacer name="verticalSpacer_11">
-                <property name="orientation">
-                 <enum>Qt::Orientation::Vertical</enum>
-                </property>
                 <property name="sizeHint" stdset="0">
                  <size>
                   <width>20</width>
@@ -9674,9 +9524,6 @@
             </item>
             <item>
              <spacer name="horizontalSpacer_12">
-              <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
-              </property>
               <property name="sizeHint" stdset="0">
                <size>
                 <width>623</width>
@@ -9693,9 +9540,6 @@
          <layout class="QHBoxLayout" name="horizontalLayout_16">
           <item>
            <spacer name="horizontalSpacer_11">
-            <property name="orientation">
-             <enum>Qt::Orientation::Horizontal</enum>
-            </property>
             <property name="sizeHint" stdset="0">
              <size>
               <width>40</width>
@@ -9720,9 +9564,6 @@
           </item>
           <item>
            <spacer name="horizontalSpacer_5">
-            <property name="orientation">
-             <enum>Qt::Orientation::Horizontal</enum>
-            </property>
             <property name="sizeHint" stdset="0">
              <size>
               <width>40</width>
@@ -9773,7 +9614,7 @@
      <x>0</x>
      <y>0</y>
      <width>1160</width>
-     <height>33</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -9796,7 +9637,7 @@
     </property>
     <widget class="QMenu" name="menu_set_level">
      <property name="inputMethodHints">
-      <set>Qt::InputMethodHint::ImhNone</set>
+      <set>Qt::ImhNone</set>
      </property>
      <property name="title">
       <string>Set Level</string>

--- a/src/TheAntFarm/ui_manager/ui_settings_preferences.py
+++ b/src/TheAntFarm/ui_manager/ui_settings_preferences.py
@@ -79,12 +79,16 @@ class UiSettingsPreferencesTab(QObject):
         self.ui.restore_settings_preferences_pb.clicked.connect(self.restore_initial_settings)
 
         self.reset_application_settings()
+        self.reset_serial_error_thresholds()
         self.ui.top_layer_color_pb.clicked.connect(lambda: self.layer_color_choice("top"))
         self.ui.bottom_layer_color_pb.clicked.connect(lambda: self.layer_color_choice("bottom"))
         self.ui.profile_layer_color_pb.clicked.connect(lambda: self.layer_color_choice("profile"))
         self.ui.drill_layer_color_pb.clicked.connect(lambda: self.layer_color_choice("drill"))
         self.ui.nc_top_layer_color_pb.clicked.connect(lambda: self.layer_color_choice("nc_top"))
         self.ui.nc_bottom_layer_color_pb.clicked.connect(lambda: self.layer_color_choice("nc_bottom"))
+
+        self.ui.serial_error_warning_threshold_sb.valueChanged.connect(lambda:self.set_serial_error_thresholds(self.ui.serial_error_warning_threshold_sb.value(), self.ui.serial_error_critical_threshold_sb.value()))
+        self.ui.serial_error_critical_threshold_sb.valueChanged.connect(lambda:self.set_serial_error_thresholds(self.ui.serial_error_warning_threshold_sb.value(), self.ui.serial_error_critical_threshold_sb.value()))
 
     def reset_application_settings(self):
         """Resets ui elements values according to application settings."""
@@ -99,6 +103,13 @@ class UiSettingsPreferencesTab(QObject):
             "background-color: {}".format(self.app_settings.layer_color["nc_top"]))
         self.ui.nc_bottom_layer_color_la.setStyleSheet(
             "background-color: {}".format(self.app_settings.layer_color["nc_bottom"]))
+
+    def reset_serial_error_thresholds(self):
+        """Reset serial error threshold UI elements according to application settings."""
+        self.ui.serial_error_warning_threshold_sb.setValue(
+            self.app_settings.serial_error_warning_threshold)
+        self.ui.serial_error_critical_threshold_sb.setValue(
+            self.app_settings.serial_error_critical_threshold)
 
     def reset_jobs_common_initial_settings(self):
         """Reset status of common jobs settings. """
@@ -144,6 +155,7 @@ class UiSettingsPreferencesTab(QObject):
     def restore_initial_settings(self):
         """Restore initial settings in ui fields. """
         self.reset_application_settings()
+        self.reset_serial_error_thresholds()
         self.reset_jobs_common_initial_settings()
         self.reset_probe_initial_settings()
         self.reset_tool_machine_initial_settings()
@@ -294,6 +306,10 @@ class UiSettingsPreferencesTab(QObject):
         self.app_settings.layer_color["nc_bottom"] = self.ui.nc_bottom_layer_color_la.palette().window().color().name()
         self.app_settings.layer_color["nc_bottom"] = self.ui.nc_bottom_layer_color_la.palette().window().color().name()
 
+        # Save serial error thresholds to app settings
+        self.app_settings.serial_error_warning_threshold = self.ui.serial_error_warning_threshold_sb.value()
+        self.app_settings.serial_error_critical_threshold = self.ui.serial_error_critical_threshold_sb.value()
+
         self.load_gcoder_cfg_s.emit()
         # Emit a signal to write all settings
         self.save_all_settings_s.emit()
@@ -340,3 +356,11 @@ class UiSettingsPreferencesTab(QObject):
                 logger.debug("color " + str(color.name()))
                 current_label.setStyleSheet("background-color: {}".format(color.name()))
                 self.set_focus_lost()
+
+    def set_serial_error_thresholds(self, warning_threshold, critical_threshold):
+        if warning_threshold >= critical_threshold:
+            self.ui.serial_error_warning_threshold_sb.setValue(critical_threshold - 1)
+            warning_threshold = critical_threshold - 1
+        self.machine_settings.serial_error_warning_threshold = warning_threshold
+        self.machine_settings.serial_error_critical_threshold = critical_threshold
+        self.set_focus_lost()

--- a/src/TheAntFarm/ui_manager/ui_settings_preferences.py
+++ b/src/TheAntFarm/ui_manager/ui_settings_preferences.py
@@ -358,9 +358,17 @@ class UiSettingsPreferencesTab(QObject):
                 self.set_focus_lost()
 
     def set_serial_error_thresholds(self, warning_threshold, critical_threshold):
-        if warning_threshold >= critical_threshold:
-            self.ui.serial_error_warning_threshold_sb.setValue(critical_threshold - 1)
-            warning_threshold = critical_threshold - 1
+        # Ensure both thresholds are at least 0
+        if warning_threshold < 0:
+            self.ui.serial_error_warning_threshold_sb.setValue(0)
+            warning_threshold = 0
+        if critical_threshold < 0:
+            self.ui.serial_error_critical_threshold_sb.setValue(0)
+            critical_threshold = 0
+        # Ensure warning threshold is less than or equal to critical threshold
+        if warning_threshold > critical_threshold:
+            self.ui.serial_error_warning_threshold_sb.setValue(critical_threshold)
+            warning_threshold = critical_threshold
         self.machine_settings.serial_error_warning_threshold = warning_threshold
         self.machine_settings.serial_error_critical_threshold = critical_threshold
         self.set_focus_lost()

--- a/src/TheAntFarm/ui_the_ant_farm.py
+++ b/src/TheAntFarm/ui_the_ant_farm.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'the_ant_farm.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.8.3
+## Created by: Qt User Interface Compiler version 6.10.0
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -94,7 +94,7 @@ class Ui_MainWindow(object):
         font = QFont()
         font.setBold(True)
         self.main_tab_widget.setFont(font)
-        self.main_tab_widget.setTabShape(QTabWidget.TabShape.Rounded)
+        self.main_tab_widget.setTabShape(QTabWidget.Rounded)
         self.main_tab_widget.setTabsClosable(False)
         self.main_tab_widget.setTabBarAutoHide(False)
         self.view_tab = QWidget()
@@ -113,15 +113,15 @@ class Ui_MainWindow(object):
         sizePolicy1.setVerticalStretch(0)
         sizePolicy1.setHeightForWidth(self.prepare_widget.sizePolicy().hasHeightForWidth())
         self.prepare_widget.setSizePolicy(sizePolicy1)
-        self.prepare_widget.setTabPosition(QTabWidget.TabPosition.North)
-        self.prepare_widget.setTabShape(QTabWidget.TabShape.Rounded)
+        self.prepare_widget.setTabPosition(QTabWidget.North)
+        self.prepare_widget.setTabShape(QTabWidget.Rounded)
         self.load_layers_tab = QWidget()
         self.load_layers_tab.setObjectName(u"load_layers_tab")
         self.verticalLayout_7 = QVBoxLayout(self.load_layers_tab)
         self.verticalLayout_7.setObjectName(u"verticalLayout_7")
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
-        self.gridLayout.setSizeConstraint(QLayout.SizeConstraint.SetFixedSize)
+        self.gridLayout.setSizeConstraint(QLayout.SetDefaultConstraint)
         self.no_copper_1_le = QLineEdit(self.load_layers_tab)
         self.no_copper_1_le.setObjectName(u"no_copper_1_le")
         sizePolicy2 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
@@ -149,7 +149,7 @@ class Ui_MainWindow(object):
         self.no_copper_2_chb.setSizePolicy(sizePolicy3)
         self.no_copper_2_chb.setChecked(True)
 
-        self.gridLayout.addWidget(self.no_copper_2_chb, 6, 2, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout.addWidget(self.no_copper_2_chb, 6, 2, 1, 1)
 
         self.profile_file_le = QLineEdit(self.load_layers_tab)
         self.profile_file_le.setObjectName(u"profile_file_le")
@@ -163,9 +163,8 @@ class Ui_MainWindow(object):
         self.view_label.setObjectName(u"view_label")
         sizePolicy3.setHeightForWidth(self.view_label.sizePolicy().hasHeightForWidth())
         self.view_label.setSizePolicy(sizePolicy3)
-        self.view_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
-        self.gridLayout.addWidget(self.view_label, 0, 2, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout.addWidget(self.view_label, 0, 2, 1, 1)
 
         self.top_view_chb = QCheckBox(self.load_layers_tab)
         self.top_view_chb.setObjectName(u"top_view_chb")
@@ -174,7 +173,7 @@ class Ui_MainWindow(object):
         self.top_view_chb.setChecked(True)
         self.top_view_chb.setTristate(False)
 
-        self.gridLayout.addWidget(self.top_view_chb, 1, 2, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout.addWidget(self.top_view_chb, 1, 2, 1, 1)
 
         self.drill_file_le = QLineEdit(self.load_layers_tab)
         self.drill_file_le.setObjectName(u"drill_file_le")
@@ -197,7 +196,7 @@ class Ui_MainWindow(object):
         self.bottom_view_chb.setSizePolicy(sizePolicy3)
         self.bottom_view_chb.setChecked(True)
 
-        self.gridLayout.addWidget(self.bottom_view_chb, 2, 2, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout.addWidget(self.bottom_view_chb, 2, 2, 1, 1)
 
         self.profile_load_pb = QPushButton(self.load_layers_tab)
         self.profile_load_pb.setObjectName(u"profile_load_pb")
@@ -220,7 +219,7 @@ class Ui_MainWindow(object):
         self.no_copper_1_chb.setSizePolicy(sizePolicy3)
         self.no_copper_1_chb.setChecked(True)
 
-        self.gridLayout.addWidget(self.no_copper_1_chb, 5, 2, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout.addWidget(self.no_copper_1_chb, 5, 2, 1, 1)
 
         self.clear_views_pb = QPushButton(self.load_layers_tab)
         self.clear_views_pb.setObjectName(u"clear_views_pb")
@@ -264,14 +263,14 @@ class Ui_MainWindow(object):
         self.drill_view_chb.setSizePolicy(sizePolicy3)
         self.drill_view_chb.setChecked(True)
 
-        self.gridLayout.addWidget(self.drill_view_chb, 4, 2, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout.addWidget(self.drill_view_chb, 4, 2, 1, 1)
 
         self.file_path_l = QLabel(self.load_layers_tab)
         self.file_path_l.setObjectName(u"file_path_l")
         sizePolicy3.setHeightForWidth(self.file_path_l.sizePolicy().hasHeightForWidth())
         self.file_path_l.setSizePolicy(sizePolicy3)
 
-        self.gridLayout.addWidget(self.file_path_l, 0, 0, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout.addWidget(self.file_path_l, 0, 0, 1, 1)
 
         self.top_file_le = QLineEdit(self.load_layers_tab)
         self.top_file_le.setObjectName(u"top_file_le")
@@ -287,7 +286,7 @@ class Ui_MainWindow(object):
         self.all_view_chb.setSizePolicy(sizePolicy3)
         self.all_view_chb.setChecked(True)
 
-        self.gridLayout.addWidget(self.all_view_chb, 8, 2, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout.addWidget(self.all_view_chb, 8, 2, 1, 1)
 
         self.profile_view_chb = QCheckBox(self.load_layers_tab)
         self.profile_view_chb.setObjectName(u"profile_view_chb")
@@ -295,9 +294,9 @@ class Ui_MainWindow(object):
         self.profile_view_chb.setSizePolicy(sizePolicy3)
         self.profile_view_chb.setChecked(True)
 
-        self.gridLayout.addWidget(self.profile_view_chb, 3, 2, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout.addWidget(self.profile_view_chb, 3, 2, 1, 1)
 
-        self.horizontal_spacer = QSpacerItem(140, 17, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontal_spacer = QSpacerItem(140, 17, QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Minimum)
 
         self.gridLayout.addItem(self.horizontal_spacer, 8, 0, 1, 1)
 
@@ -308,7 +307,7 @@ class Ui_MainWindow(object):
 
         self.verticalLayout_7.addLayout(self.gridLayout)
 
-        self.verticalSpacer = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+        self.verticalSpacer = QSpacerItem(20, 40, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.verticalLayout_7.addItem(self.verticalSpacer)
 
@@ -364,7 +363,7 @@ class Ui_MainWindow(object):
 
         self.gridLayout_2.addWidget(self.top_n_passes_la, 1, 0, 1, 1)
 
-        self.top_vertical_spacer = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+        self.top_vertical_spacer = QSpacerItem(20, 40, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.gridLayout_2.addItem(self.top_vertical_spacer, 10, 0, 1, 2)
 
@@ -414,7 +413,7 @@ class Ui_MainWindow(object):
         self.top_tool_diameter_dsb.setMinimum(0.000100000000000)
         self.top_tool_diameter_dsb.setMaximum(100.000000000000000)
         self.top_tool_diameter_dsb.setSingleStep(0.000100000000000)
-        self.top_tool_diameter_dsb.setStepType(QAbstractSpinBox.StepType.DefaultStepType)
+        self.top_tool_diameter_dsb.setStepType(QAbstractSpinBox.DefaultStepType)
 
         self.gridLayout_2.addWidget(self.top_tool_diameter_dsb, 0, 1, 1, 1)
 
@@ -534,7 +533,7 @@ class Ui_MainWindow(object):
 
         self.gridLayout_3.addWidget(self.bottom_overlap_dsb, 3, 1, 1, 1)
 
-        self.bottom_vertical_spacer = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+        self.bottom_vertical_spacer = QSpacerItem(20, 40, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.gridLayout_3.addItem(self.bottom_vertical_spacer, 11, 0, 1, 2)
 
@@ -688,7 +687,7 @@ class Ui_MainWindow(object):
         self.profile_multi_depth_chb.setSizePolicy(sizePolicy2)
         self.profile_multi_depth_chb.setMinimumSize(QSize(123, 0))
 
-        self.gridLayout_4.addWidget(self.profile_multi_depth_chb, 2, 3, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout_4.addWidget(self.profile_multi_depth_chb, 2, 3, 1, 1)
 
         self.profile_z_feed_rate_la = QLabel(self.profile_page)
         self.profile_z_feed_rate_la.setObjectName(u"profile_z_feed_rate_la")
@@ -710,7 +709,7 @@ class Ui_MainWindow(object):
 
         self.gridLayout_4.addWidget(self.profile_tap_size_la, 12, 1, 1, 1)
 
-        self.profile_vertical_spacer = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+        self.profile_vertical_spacer = QSpacerItem(20, 40, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.gridLayout_4.addItem(self.profile_vertical_spacer, 15, 1, 1, 3)
 
@@ -788,7 +787,7 @@ class Ui_MainWindow(object):
         self.add_drill_tool_tb = QToolButton(self.drill_page)
         self.add_drill_tool_tb.setObjectName(u"add_drill_tool_tb")
 
-        self.gridLayout_5.addWidget(self.add_drill_tool_tb, 2, 1, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout_5.addWidget(self.add_drill_tool_tb, 2, 1, 1, 1)
 
         self.drill_z_feed_rate_la = QLabel(self.drill_page)
         self.drill_z_feed_rate_la.setObjectName(u"drill_z_feed_rate_la")
@@ -823,7 +822,7 @@ class Ui_MainWindow(object):
         self.remove_drill_tool_tb = QToolButton(self.drill_page)
         self.remove_drill_tool_tb.setObjectName(u"remove_drill_tool_tb")
 
-        self.gridLayout_5.addWidget(self.remove_drill_tool_tb, 2, 2, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout_5.addWidget(self.remove_drill_tool_tb, 2, 2, 1, 1)
 
         self.drill_milling_tool_chb = QCheckBox(self.drill_page)
         self.drill_milling_tool_chb.setObjectName(u"drill_milling_tool_chb")
@@ -852,10 +851,10 @@ class Ui_MainWindow(object):
         __qtablewidgetitem1 = QTableWidgetItem()
         self.drill_tw.setHorizontalHeaderItem(1, __qtablewidgetitem1)
         self.drill_tw.setObjectName(u"drill_tw")
-        self.drill_tw.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
+        self.drill_tw.setSelectionBehavior(QAbstractItemView.SelectItems)
         self.drill_tw.setColumnCount(2)
 
-        self.gridLayout_5.addWidget(self.drill_tw, 0, 1, 1, 2, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+        self.gridLayout_5.addWidget(self.drill_tw, 0, 1, 1, 2)
 
         self.drill_cut_z_dsb = QDoubleSpinBox(self.drill_page)
         self.drill_cut_z_dsb.setObjectName(u"drill_cut_z_dsb")
@@ -894,7 +893,7 @@ class Ui_MainWindow(object):
 
         self.gridLayout_5.addWidget(self.drill_milling_tool_diameter_la, 4, 1, 1, 1)
 
-        self.drill_vertical_spacer = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+        self.drill_vertical_spacer = QSpacerItem(20, 40, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.gridLayout_5.addItem(self.drill_vertical_spacer, 15, 1, 1, 2)
 
@@ -1030,7 +1029,7 @@ class Ui_MainWindow(object):
 
         self.gridLayout_6.addWidget(self.nc_top_z_feed_rate_dsb, 6, 1, 1, 1)
 
-        self.nc_top_vertical_spacer = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+        self.nc_top_vertical_spacer = QSpacerItem(20, 40, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.gridLayout_6.addItem(self.nc_top_vertical_spacer, 7, 0, 1, 2)
 
@@ -1112,7 +1111,7 @@ class Ui_MainWindow(object):
 
         self.gridLayout_7.addWidget(self.nc_bottom_tool_diameter_la, 0, 0, 1, 1)
 
-        self.nc_bottom_vertical_spacer = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+        self.nc_bottom_vertical_spacer = QSpacerItem(20, 40, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.gridLayout_7.addItem(self.nc_bottom_vertical_spacer, 8, 0, 1, 2)
 
@@ -1242,10 +1241,10 @@ class Ui_MainWindow(object):
         self.gcode_tw.setSizePolicy(sizePolicy6)
         self.gcode_tw.setMinimumSize(QSize(320, 0))
         self.gcode_tw.setMaximumSize(QSize(320, 16777215))
-        self.gcode_tw.setFrameShape(QFrame.Shape.NoFrame)
-        self.gcode_tw.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
-        self.gcode_tw.setSelectionMode(QAbstractItemView.SelectionMode.MultiSelection)
-        self.gcode_tw.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
+        self.gcode_tw.setFrameShape(QFrame.NoFrame)
+        self.gcode_tw.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+        self.gcode_tw.setSelectionMode(QAbstractItemView.NoSelection)
+        self.gcode_tw.setSelectionBehavior(QAbstractItemView.SelectItems)
         self.gcode_tw.setShowGrid(False)
         self.gcode_tw.setColumnCount(2)
         self.gcode_tw.horizontalHeader().setCascadingSectionResizes(True)
@@ -1300,7 +1299,7 @@ class Ui_MainWindow(object):
         self.verticalLayout_10.setContentsMargins(0, 0, 0, 0)
         self.controlsVerticalLayout = QVBoxLayout()
         self.controlsVerticalLayout.setObjectName(u"controlsVerticalLayout")
-        self.controlsVerticalLayout.setSizeConstraint(QLayout.SizeConstraint.SetDefaultConstraint)
+        self.controlsVerticalLayout.setSizeConstraint(QLayout.SetDefaultConstraint)
         self.droGridLayout = QGridLayout()
         self.droGridLayout.setObjectName(u"droGridLayout")
         self.droGridLayout.setHorizontalSpacing(0)
@@ -1317,7 +1316,7 @@ class Ui_MainWindow(object):
         self.zero_xy_pb.setMaximumSize(QSize(16777215, 23))
         self.zero_xy_pb.setFont(font)
 
-        self.droGridLayout.addWidget(self.zero_xy_pb, 3, 0, 1, 1, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+        self.droGridLayout.addWidget(self.zero_xy_pb, 3, 0, 1, 1)
 
         self.zero_y_pb = QPushButton(self.sender_tab)
         self.zero_y_pb.setObjectName(u"zero_y_pb")
@@ -1327,7 +1326,7 @@ class Ui_MainWindow(object):
         self.zero_y_pb.setMaximumSize(QSize(16777215, 23))
         self.zero_y_pb.setFont(font)
 
-        self.droGridLayout.addWidget(self.zero_y_pb, 3, 2, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.droGridLayout.addWidget(self.zero_y_pb, 3, 2, 1, 1)
 
         self.z_axis_l = QLabel(self.sender_tab)
         self.z_axis_l.setObjectName(u"z_axis_l")
@@ -1336,12 +1335,10 @@ class Ui_MainWindow(object):
         self.z_axis_l.setMinimumSize(QSize(0, 12))
         self.z_axis_l.setMaximumSize(QSize(16777215, 13))
         self.z_axis_l.setFont(font)
-        self.z_axis_l.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
-        self.z_axis_l.setFrameShape(QFrame.Shape.NoFrame)
-        self.z_axis_l.setFrameShadow(QFrame.Shadow.Plain)
-        self.z_axis_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.z_axis_l.setLayoutDirection(Qt.LeftToRight)
+        self.z_axis_l.setFrameShape(QFrame.NoFrame)
 
-        self.droGridLayout.addWidget(self.z_axis_l, 0, 3, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.droGridLayout.addWidget(self.z_axis_l, 0, 3, 1, 1)
 
         self.wpos_y_l = QLabel(self.sender_tab)
         self.wpos_y_l.setObjectName(u"wpos_y_l")
@@ -1349,12 +1346,10 @@ class Ui_MainWindow(object):
         self.wpos_y_l.setSizePolicy(sizePolicy7)
         self.wpos_y_l.setMinimumSize(QSize(0, 12))
         self.wpos_y_l.setMaximumSize(QSize(16777215, 13))
-        self.wpos_y_l.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
-        self.wpos_y_l.setFrameShape(QFrame.Shape.NoFrame)
-        self.wpos_y_l.setFrameShadow(QFrame.Shadow.Plain)
-        self.wpos_y_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.wpos_y_l.setLayoutDirection(Qt.LeftToRight)
+        self.wpos_y_l.setFrameShape(QFrame.NoFrame)
 
-        self.droGridLayout.addWidget(self.wpos_y_l, 2, 2, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.droGridLayout.addWidget(self.wpos_y_l, 2, 2, 1, 1)
 
         self.wpos_l = QLabel(self.sender_tab)
         self.wpos_l.setObjectName(u"wpos_l")
@@ -1363,12 +1358,10 @@ class Ui_MainWindow(object):
         self.wpos_l.setMinimumSize(QSize(0, 12))
         self.wpos_l.setMaximumSize(QSize(16777215, 13))
         self.wpos_l.setFont(font)
-        self.wpos_l.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
-        self.wpos_l.setFrameShape(QFrame.Shape.NoFrame)
-        self.wpos_l.setFrameShadow(QFrame.Shadow.Plain)
-        self.wpos_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.wpos_l.setLayoutDirection(Qt.LeftToRight)
+        self.wpos_l.setFrameShape(QFrame.NoFrame)
 
-        self.droGridLayout.addWidget(self.wpos_l, 2, 0, 1, 1, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+        self.droGridLayout.addWidget(self.wpos_l, 2, 0, 1, 1)
 
         self.zero_z_pb = QPushButton(self.sender_tab)
         self.zero_z_pb.setObjectName(u"zero_z_pb")
@@ -1378,7 +1371,7 @@ class Ui_MainWindow(object):
         self.zero_z_pb.setMaximumSize(QSize(16777215, 23))
         self.zero_z_pb.setFont(font)
 
-        self.droGridLayout.addWidget(self.zero_z_pb, 3, 3, 1, 1, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+        self.droGridLayout.addWidget(self.zero_z_pb, 3, 3, 1, 1)
 
         self.mpos_y_l = QLabel(self.sender_tab)
         self.mpos_y_l.setObjectName(u"mpos_y_l")
@@ -1386,12 +1379,10 @@ class Ui_MainWindow(object):
         self.mpos_y_l.setSizePolicy(sizePolicy7)
         self.mpos_y_l.setMinimumSize(QSize(0, 12))
         self.mpos_y_l.setMaximumSize(QSize(16777215, 13))
-        self.mpos_y_l.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
-        self.mpos_y_l.setFrameShape(QFrame.Shape.NoFrame)
-        self.mpos_y_l.setFrameShadow(QFrame.Shadow.Plain)
-        self.mpos_y_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.mpos_y_l.setLayoutDirection(Qt.LeftToRight)
+        self.mpos_y_l.setFrameShape(QFrame.NoFrame)
 
-        self.droGridLayout.addWidget(self.mpos_y_l, 1, 2, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.droGridLayout.addWidget(self.mpos_y_l, 1, 2, 1, 1)
 
         self.mpos_z_l = QLabel(self.sender_tab)
         self.mpos_z_l.setObjectName(u"mpos_z_l")
@@ -1399,12 +1390,10 @@ class Ui_MainWindow(object):
         self.mpos_z_l.setSizePolicy(sizePolicy7)
         self.mpos_z_l.setMinimumSize(QSize(0, 12))
         self.mpos_z_l.setMaximumSize(QSize(16777215, 13))
-        self.mpos_z_l.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
-        self.mpos_z_l.setFrameShape(QFrame.Shape.NoFrame)
-        self.mpos_z_l.setFrameShadow(QFrame.Shadow.Plain)
-        self.mpos_z_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.mpos_z_l.setLayoutDirection(Qt.LeftToRight)
+        self.mpos_z_l.setFrameShape(QFrame.NoFrame)
 
-        self.droGridLayout.addWidget(self.mpos_z_l, 1, 3, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.droGridLayout.addWidget(self.mpos_z_l, 1, 3, 1, 1)
 
         self.x_axis_l = QLabel(self.sender_tab)
         self.x_axis_l.setObjectName(u"x_axis_l")
@@ -1413,12 +1402,10 @@ class Ui_MainWindow(object):
         self.x_axis_l.setMinimumSize(QSize(0, 12))
         self.x_axis_l.setMaximumSize(QSize(16777215, 13))
         self.x_axis_l.setFont(font)
-        self.x_axis_l.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
-        self.x_axis_l.setFrameShape(QFrame.Shape.NoFrame)
-        self.x_axis_l.setFrameShadow(QFrame.Shadow.Plain)
-        self.x_axis_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.x_axis_l.setLayoutDirection(Qt.LeftToRight)
+        self.x_axis_l.setFrameShape(QFrame.NoFrame)
 
-        self.droGridLayout.addWidget(self.x_axis_l, 0, 1, 1, 1, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+        self.droGridLayout.addWidget(self.x_axis_l, 0, 1, 1, 1)
 
         self.wpos_x_l = QLabel(self.sender_tab)
         self.wpos_x_l.setObjectName(u"wpos_x_l")
@@ -1426,12 +1413,10 @@ class Ui_MainWindow(object):
         self.wpos_x_l.setSizePolicy(sizePolicy7)
         self.wpos_x_l.setMinimumSize(QSize(0, 12))
         self.wpos_x_l.setMaximumSize(QSize(16777215, 13))
-        self.wpos_x_l.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
-        self.wpos_x_l.setFrameShape(QFrame.Shape.NoFrame)
-        self.wpos_x_l.setFrameShadow(QFrame.Shadow.Plain)
-        self.wpos_x_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.wpos_x_l.setLayoutDirection(Qt.LeftToRight)
+        self.wpos_x_l.setFrameShape(QFrame.NoFrame)
 
-        self.droGridLayout.addWidget(self.wpos_x_l, 2, 1, 1, 1, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+        self.droGridLayout.addWidget(self.wpos_x_l, 2, 1, 1, 1)
 
         self.axis_l = QLabel(self.sender_tab)
         self.axis_l.setObjectName(u"axis_l")
@@ -1440,12 +1425,10 @@ class Ui_MainWindow(object):
         self.axis_l.setMinimumSize(QSize(0, 12))
         self.axis_l.setMaximumSize(QSize(16777215, 13))
         self.axis_l.setFont(font)
-        self.axis_l.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
-        self.axis_l.setFrameShape(QFrame.Shape.NoFrame)
-        self.axis_l.setFrameShadow(QFrame.Shadow.Plain)
-        self.axis_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.axis_l.setLayoutDirection(Qt.LeftToRight)
+        self.axis_l.setFrameShape(QFrame.NoFrame)
 
-        self.droGridLayout.addWidget(self.axis_l, 0, 0, 1, 1, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+        self.droGridLayout.addWidget(self.axis_l, 0, 0, 1, 1)
 
         self.mpos_l = QLabel(self.sender_tab)
         self.mpos_l.setObjectName(u"mpos_l")
@@ -1454,12 +1437,10 @@ class Ui_MainWindow(object):
         self.mpos_l.setMinimumSize(QSize(0, 12))
         self.mpos_l.setMaximumSize(QSize(16777215, 13))
         self.mpos_l.setFont(font)
-        self.mpos_l.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
-        self.mpos_l.setFrameShape(QFrame.Shape.NoFrame)
-        self.mpos_l.setFrameShadow(QFrame.Shadow.Plain)
-        self.mpos_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.mpos_l.setLayoutDirection(Qt.LeftToRight)
+        self.mpos_l.setFrameShape(QFrame.NoFrame)
 
-        self.droGridLayout.addWidget(self.mpos_l, 1, 0, 1, 1, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+        self.droGridLayout.addWidget(self.mpos_l, 1, 0, 1, 1)
 
         self.wpos_z_l = QLabel(self.sender_tab)
         self.wpos_z_l.setObjectName(u"wpos_z_l")
@@ -1467,12 +1448,10 @@ class Ui_MainWindow(object):
         self.wpos_z_l.setSizePolicy(sizePolicy7)
         self.wpos_z_l.setMinimumSize(QSize(0, 12))
         self.wpos_z_l.setMaximumSize(QSize(16777215, 13))
-        self.wpos_z_l.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
-        self.wpos_z_l.setFrameShape(QFrame.Shape.NoFrame)
-        self.wpos_z_l.setFrameShadow(QFrame.Shadow.Plain)
-        self.wpos_z_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.wpos_z_l.setLayoutDirection(Qt.LeftToRight)
+        self.wpos_z_l.setFrameShape(QFrame.NoFrame)
 
-        self.droGridLayout.addWidget(self.wpos_z_l, 2, 3, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.droGridLayout.addWidget(self.wpos_z_l, 2, 3, 1, 1)
 
         self.zero_x_pb = QPushButton(self.sender_tab)
         self.zero_x_pb.setObjectName(u"zero_x_pb")
@@ -1482,7 +1461,7 @@ class Ui_MainWindow(object):
         self.zero_x_pb.setMaximumSize(QSize(16777215, 23))
         self.zero_x_pb.setFont(font)
 
-        self.droGridLayout.addWidget(self.zero_x_pb, 3, 1, 1, 1, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+        self.droGridLayout.addWidget(self.zero_x_pb, 3, 1, 1, 1)
 
         self.y_axis_l = QLabel(self.sender_tab)
         self.y_axis_l.setObjectName(u"y_axis_l")
@@ -1491,12 +1470,10 @@ class Ui_MainWindow(object):
         self.y_axis_l.setMinimumSize(QSize(0, 12))
         self.y_axis_l.setMaximumSize(QSize(16777215, 13))
         self.y_axis_l.setFont(font)
-        self.y_axis_l.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
-        self.y_axis_l.setFrameShape(QFrame.Shape.NoFrame)
-        self.y_axis_l.setFrameShadow(QFrame.Shadow.Plain)
-        self.y_axis_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.y_axis_l.setLayoutDirection(Qt.LeftToRight)
+        self.y_axis_l.setFrameShape(QFrame.NoFrame)
 
-        self.droGridLayout.addWidget(self.y_axis_l, 0, 2, 1, 1, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+        self.droGridLayout.addWidget(self.y_axis_l, 0, 2, 1, 1)
 
         self.mpos_x_l = QLabel(self.sender_tab)
         self.mpos_x_l.setObjectName(u"mpos_x_l")
@@ -1504,19 +1481,17 @@ class Ui_MainWindow(object):
         self.mpos_x_l.setSizePolicy(sizePolicy7)
         self.mpos_x_l.setMinimumSize(QSize(0, 12))
         self.mpos_x_l.setMaximumSize(QSize(16777215, 13))
-        self.mpos_x_l.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
-        self.mpos_x_l.setFrameShape(QFrame.Shape.NoFrame)
-        self.mpos_x_l.setFrameShadow(QFrame.Shadow.Plain)
-        self.mpos_x_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.mpos_x_l.setLayoutDirection(Qt.LeftToRight)
+        self.mpos_x_l.setFrameShape(QFrame.NoFrame)
 
-        self.droGridLayout.addWidget(self.mpos_x_l, 1, 1, 1, 1, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+        self.droGridLayout.addWidget(self.mpos_x_l, 1, 1, 1, 1)
 
 
         self.controlsVerticalLayout.addLayout(self.droGridLayout)
 
         self.line = QFrame(self.sender_tab)
         self.line.setObjectName(u"line")
-        self.line.setFrameShape(QFrame.Shape.HLine)
+        self.line.setFrameShape(QFrame.Shape.VLine)
         self.line.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.controlsVerticalLayout.addWidget(self.line)
@@ -2389,7 +2364,7 @@ class Ui_MainWindow(object):
         icon15.addFile(u":/resources/resources/icons/gray-refresh.svg", QSize(), QIcon.Mode.Disabled, QIcon.State.On)
         self.soft_reset_tb.setIcon(icon15)
         self.soft_reset_tb.setIconSize(QSize(64, 64))
-        self.soft_reset_tb.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
+        self.soft_reset_tb.setToolButtonStyle(Qt.ToolButtonIconOnly)
 
         self.verticalLayout_3.addWidget(self.soft_reset_tb)
 
@@ -2401,100 +2376,87 @@ class Ui_MainWindow(object):
         self.status_l.setMaximumSize(QSize(120, 16777215))
         palette = QPalette()
         brush = QBrush(QColor(0, 0, 0, 255))
-        brush.setStyle(Qt.SolidPattern)
-        palette.setBrush(QPalette.Active, QPalette.WindowText, brush)
+        brush.setStyle(Qt.BrushStyle.SolidPattern)
+        palette.setBrush(QPalette.ColorGroup.Active, QPalette.ColorRole.WindowText, brush)
         brush1 = QBrush(QColor(0, 255, 127, 255))
-        brush1.setStyle(Qt.SolidPattern)
-        palette.setBrush(QPalette.Active, QPalette.Button, brush1)
+        brush1.setStyle(Qt.BrushStyle.SolidPattern)
+        palette.setBrush(QPalette.ColorGroup.Active, QPalette.ColorRole.Button, brush1)
         brush2 = QBrush(QColor(127, 255, 191, 255))
-        brush2.setStyle(Qt.SolidPattern)
-        palette.setBrush(QPalette.Active, QPalette.Light, brush2)
+        brush2.setStyle(Qt.BrushStyle.SolidPattern)
+        palette.setBrush(QPalette.ColorGroup.Active, QPalette.ColorRole.Light, brush2)
         brush3 = QBrush(QColor(63, 255, 159, 255))
-        brush3.setStyle(Qt.SolidPattern)
-        palette.setBrush(QPalette.Active, QPalette.Midlight, brush3)
+        brush3.setStyle(Qt.BrushStyle.SolidPattern)
+        palette.setBrush(QPalette.ColorGroup.Active, QPalette.ColorRole.Midlight, brush3)
         brush4 = QBrush(QColor(0, 127, 63, 255))
-        brush4.setStyle(Qt.SolidPattern)
-        palette.setBrush(QPalette.Active, QPalette.Dark, brush4)
+        brush4.setStyle(Qt.BrushStyle.SolidPattern)
+        palette.setBrush(QPalette.ColorGroup.Active, QPalette.ColorRole.Dark, brush4)
         brush5 = QBrush(QColor(0, 170, 84, 255))
-        brush5.setStyle(Qt.SolidPattern)
-        palette.setBrush(QPalette.Active, QPalette.Mid, brush5)
+        brush5.setStyle(Qt.BrushStyle.SolidPattern)
+        palette.setBrush(QPalette.ColorGroup.Active, QPalette.ColorRole.Mid, brush5)
         brush6 = QBrush(QColor(0, 255, 255, 255))
-        brush6.setStyle(Qt.SolidPattern)
-        palette.setBrush(QPalette.Active, QPalette.Text, brush6)
+        brush6.setStyle(Qt.BrushStyle.SolidPattern)
+        palette.setBrush(QPalette.ColorGroup.Active, QPalette.ColorRole.Text, brush6)
         brush7 = QBrush(QColor(170, 170, 255, 255))
-        brush7.setStyle(Qt.SolidPattern)
-        palette.setBrush(QPalette.Active, QPalette.BrightText, brush7)
-        palette.setBrush(QPalette.Active, QPalette.ButtonText, brush)
+        brush7.setStyle(Qt.BrushStyle.SolidPattern)
+        palette.setBrush(QPalette.ColorGroup.Active, QPalette.ColorRole.BrightText, brush7)
+        palette.setBrush(QPalette.ColorGroup.Active, QPalette.ColorRole.ButtonText, brush)
         brush8 = QBrush(QColor(255, 255, 255, 255))
-        brush8.setStyle(Qt.SolidPattern)
-        palette.setBrush(QPalette.Active, QPalette.Base, brush8)
-        palette.setBrush(QPalette.Active, QPalette.Window, brush1)
-        palette.setBrush(QPalette.Active, QPalette.Shadow, brush)
+        brush8.setStyle(Qt.BrushStyle.SolidPattern)
+        palette.setBrush(QPalette.ColorGroup.Active, QPalette.ColorRole.Base, brush8)
+        palette.setBrush(QPalette.ColorGroup.Active, QPalette.ColorRole.Window, brush1)
+        palette.setBrush(QPalette.ColorGroup.Active, QPalette.ColorRole.Shadow, brush)
         brush9 = QBrush(QColor(170, 170, 0, 255))
-        brush9.setStyle(Qt.SolidPattern)
-        palette.setBrush(QPalette.Active, QPalette.HighlightedText, brush9)
-        palette.setBrush(QPalette.Active, QPalette.AlternateBase, brush2)
+        brush9.setStyle(Qt.BrushStyle.SolidPattern)
+        palette.setBrush(QPalette.ColorGroup.Active, QPalette.ColorRole.HighlightedText, brush9)
+        palette.setBrush(QPalette.ColorGroup.Active, QPalette.ColorRole.AlternateBase, brush2)
         brush10 = QBrush(QColor(255, 255, 220, 255))
-        brush10.setStyle(Qt.SolidPattern)
-        palette.setBrush(QPalette.Active, QPalette.ToolTipBase, brush10)
-        palette.setBrush(QPalette.Active, QPalette.ToolTipText, brush)
+        brush10.setStyle(Qt.BrushStyle.SolidPattern)
+        palette.setBrush(QPalette.ColorGroup.Active, QPalette.ColorRole.ToolTipBase, brush10)
+        palette.setBrush(QPalette.ColorGroup.Active, QPalette.ColorRole.ToolTipText, brush)
         brush11 = QBrush(QColor(255, 255, 127, 128))
-        brush11.setStyle(Qt.SolidPattern)
+        brush11.setStyle(Qt.BrushStyle.SolidPattern)
 #if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
-        palette.setBrush(QPalette.Active, QPalette.PlaceholderText, brush11)
+        palette.setBrush(QPalette.ColorGroup.Active, QPalette.ColorRole.PlaceholderText, brush11)
 #endif
-        brush12 = QBrush(QColor(76, 194, 255, 255))
-        brush12.setStyle(Qt.SolidPattern)
-#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
-        palette.setBrush(QPalette.Active, QPalette.Accent, brush12)
-#endif
-        palette.setBrush(QPalette.Inactive, QPalette.WindowText, brush)
-        palette.setBrush(QPalette.Inactive, QPalette.Button, brush1)
-        palette.setBrush(QPalette.Inactive, QPalette.Light, brush2)
-        palette.setBrush(QPalette.Inactive, QPalette.Midlight, brush3)
-        palette.setBrush(QPalette.Inactive, QPalette.Dark, brush4)
-        palette.setBrush(QPalette.Inactive, QPalette.Mid, brush5)
-        palette.setBrush(QPalette.Inactive, QPalette.Text, brush)
-        palette.setBrush(QPalette.Inactive, QPalette.BrightText, brush8)
-        palette.setBrush(QPalette.Inactive, QPalette.ButtonText, brush)
-        palette.setBrush(QPalette.Inactive, QPalette.Base, brush8)
-        palette.setBrush(QPalette.Inactive, QPalette.Window, brush1)
-        palette.setBrush(QPalette.Inactive, QPalette.Shadow, brush)
-        palette.setBrush(QPalette.Inactive, QPalette.HighlightedText, brush)
-        palette.setBrush(QPalette.Inactive, QPalette.AlternateBase, brush2)
-        palette.setBrush(QPalette.Inactive, QPalette.ToolTipBase, brush10)
-        palette.setBrush(QPalette.Inactive, QPalette.ToolTipText, brush)
-        brush13 = QBrush(QColor(0, 0, 0, 128))
-        brush13.setStyle(Qt.SolidPattern)
+        palette.setBrush(QPalette.ColorGroup.Inactive, QPalette.ColorRole.WindowText, brush)
+        palette.setBrush(QPalette.ColorGroup.Inactive, QPalette.ColorRole.Button, brush1)
+        palette.setBrush(QPalette.ColorGroup.Inactive, QPalette.ColorRole.Light, brush2)
+        palette.setBrush(QPalette.ColorGroup.Inactive, QPalette.ColorRole.Midlight, brush3)
+        palette.setBrush(QPalette.ColorGroup.Inactive, QPalette.ColorRole.Dark, brush4)
+        palette.setBrush(QPalette.ColorGroup.Inactive, QPalette.ColorRole.Mid, brush5)
+        palette.setBrush(QPalette.ColorGroup.Inactive, QPalette.ColorRole.Text, brush)
+        palette.setBrush(QPalette.ColorGroup.Inactive, QPalette.ColorRole.BrightText, brush8)
+        palette.setBrush(QPalette.ColorGroup.Inactive, QPalette.ColorRole.ButtonText, brush)
+        palette.setBrush(QPalette.ColorGroup.Inactive, QPalette.ColorRole.Base, brush8)
+        palette.setBrush(QPalette.ColorGroup.Inactive, QPalette.ColorRole.Window, brush1)
+        palette.setBrush(QPalette.ColorGroup.Inactive, QPalette.ColorRole.Shadow, brush)
+        palette.setBrush(QPalette.ColorGroup.Inactive, QPalette.ColorRole.HighlightedText, brush)
+        palette.setBrush(QPalette.ColorGroup.Inactive, QPalette.ColorRole.AlternateBase, brush2)
+        palette.setBrush(QPalette.ColorGroup.Inactive, QPalette.ColorRole.ToolTipBase, brush10)
+        palette.setBrush(QPalette.ColorGroup.Inactive, QPalette.ColorRole.ToolTipText, brush)
+        brush12 = QBrush(QColor(0, 0, 0, 128))
+        brush12.setStyle(Qt.BrushStyle.SolidPattern)
 #if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
-        palette.setBrush(QPalette.Inactive, QPalette.PlaceholderText, brush13)
+        palette.setBrush(QPalette.ColorGroup.Inactive, QPalette.ColorRole.PlaceholderText, brush12)
 #endif
-#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
-        palette.setBrush(QPalette.Inactive, QPalette.Accent, brush12)
-#endif
-        palette.setBrush(QPalette.Disabled, QPalette.WindowText, brush4)
-        palette.setBrush(QPalette.Disabled, QPalette.Button, brush1)
-        palette.setBrush(QPalette.Disabled, QPalette.Light, brush2)
-        palette.setBrush(QPalette.Disabled, QPalette.Midlight, brush3)
-        palette.setBrush(QPalette.Disabled, QPalette.Dark, brush4)
-        palette.setBrush(QPalette.Disabled, QPalette.Mid, brush5)
-        palette.setBrush(QPalette.Disabled, QPalette.Text, brush4)
-        palette.setBrush(QPalette.Disabled, QPalette.BrightText, brush8)
-        palette.setBrush(QPalette.Disabled, QPalette.ButtonText, brush4)
-        palette.setBrush(QPalette.Disabled, QPalette.Base, brush1)
-        palette.setBrush(QPalette.Disabled, QPalette.Window, brush1)
-        palette.setBrush(QPalette.Disabled, QPalette.Shadow, brush)
-        palette.setBrush(QPalette.Disabled, QPalette.HighlightedText, brush8)
-        palette.setBrush(QPalette.Disabled, QPalette.AlternateBase, brush1)
-        palette.setBrush(QPalette.Disabled, QPalette.ToolTipBase, brush10)
-        palette.setBrush(QPalette.Disabled, QPalette.ToolTipText, brush)
+        palette.setBrush(QPalette.ColorGroup.Disabled, QPalette.ColorRole.WindowText, brush4)
+        palette.setBrush(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Button, brush1)
+        palette.setBrush(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Light, brush2)
+        palette.setBrush(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Midlight, brush3)
+        palette.setBrush(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Dark, brush4)
+        palette.setBrush(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Mid, brush5)
+        palette.setBrush(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Text, brush4)
+        palette.setBrush(QPalette.ColorGroup.Disabled, QPalette.ColorRole.BrightText, brush8)
+        palette.setBrush(QPalette.ColorGroup.Disabled, QPalette.ColorRole.ButtonText, brush4)
+        palette.setBrush(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Base, brush1)
+        palette.setBrush(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Window, brush1)
+        palette.setBrush(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Shadow, brush)
+        palette.setBrush(QPalette.ColorGroup.Disabled, QPalette.ColorRole.HighlightedText, brush8)
+        palette.setBrush(QPalette.ColorGroup.Disabled, QPalette.ColorRole.AlternateBase, brush1)
+        palette.setBrush(QPalette.ColorGroup.Disabled, QPalette.ColorRole.ToolTipBase, brush10)
+        palette.setBrush(QPalette.ColorGroup.Disabled, QPalette.ColorRole.ToolTipText, brush)
 #if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
-        palette.setBrush(QPalette.Disabled, QPalette.PlaceholderText, brush13)
-#endif
-        brush14 = QBrush(QColor(157, 157, 157, 255))
-        brush14.setStyle(Qt.SolidPattern)
-#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
-        palette.setBrush(QPalette.Disabled, QPalette.Accent, brush14)
+        palette.setBrush(QPalette.ColorGroup.Disabled, QPalette.ColorRole.PlaceholderText, brush12)
 #endif
         self.status_l.setPalette(palette)
         font2 = QFont()
@@ -2502,9 +2464,7 @@ class Ui_MainWindow(object):
         font2.setPointSize(10)
         font2.setBold(True)
         self.status_l.setFont(font2)
-        self.status_l.setFrameShape(QFrame.Shape.StyledPanel)
-        self.status_l.setFrameShadow(QFrame.Shadow.Plain)
-        self.status_l.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.status_l.setFrameShape(QFrame.NoFrame)
         self.status_l.setWordWrap(True)
 
         self.verticalLayout_3.addWidget(self.status_l)
@@ -2521,7 +2481,7 @@ class Ui_MainWindow(object):
         icon16.addFile(u":/resources/resources/icons/gray-unlock-padlock.svg", QSize(), QIcon.Mode.Disabled, QIcon.State.On)
         self.unlock_tb.setIcon(icon16)
         self.unlock_tb.setIconSize(QSize(64, 64))
-        self.unlock_tb.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
+        self.unlock_tb.setToolButtonStyle(Qt.ToolButtonIconOnly)
 
         self.verticalLayout_3.addWidget(self.unlock_tb)
 
@@ -2537,7 +2497,7 @@ class Ui_MainWindow(object):
         icon17.addFile(u":/resources/resources/icons/gray-home.svg", QSize(), QIcon.Mode.Disabled, QIcon.State.On)
         self.homing_tb.setIcon(icon17)
         self.homing_tb.setIconSize(QSize(64, 64))
-        self.homing_tb.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
+        self.homing_tb.setToolButtonStyle(Qt.ToolButtonIconOnly)
 
         self.verticalLayout_3.addWidget(self.homing_tb)
 
@@ -2553,7 +2513,7 @@ class Ui_MainWindow(object):
         icon18.addFile(u":/resources/resources/icons/gray-play-button-arrowhead.svg", QSize(), QIcon.Mode.Disabled, QIcon.State.On)
         self.play_tb.setIcon(icon18)
         self.play_tb.setIconSize(QSize(64, 64))
-        self.play_tb.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
+        self.play_tb.setToolButtonStyle(Qt.ToolButtonIconOnly)
 
         self.verticalLayout_3.addWidget(self.play_tb)
 
@@ -2569,7 +2529,7 @@ class Ui_MainWindow(object):
         icon19.addFile(u":/resources/resources/icons/gray-pause-multimedia-big-gross-symbol-lines.svg", QSize(), QIcon.Mode.Disabled, QIcon.State.On)
         self.pause_resume_tb.setIcon(icon19)
         self.pause_resume_tb.setIconSize(QSize(64, 64))
-        self.pause_resume_tb.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
+        self.pause_resume_tb.setToolButtonStyle(Qt.ToolButtonIconOnly)
 
         self.verticalLayout_3.addWidget(self.pause_resume_tb)
 
@@ -2585,7 +2545,7 @@ class Ui_MainWindow(object):
         icon20.addFile(u":/resources/resources/icons/gray-stop-button-black-rounded-square.svg", QSize(), QIcon.Mode.Disabled, QIcon.State.On)
         self.stop_tb.setIcon(icon20)
         self.stop_tb.setIconSize(QSize(64, 64))
-        self.stop_tb.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
+        self.stop_tb.setToolButtonStyle(Qt.ToolButtonIconOnly)
 
         self.verticalLayout_3.addWidget(self.stop_tb)
 
@@ -2601,7 +2561,7 @@ class Ui_MainWindow(object):
         icon21.addFile(u":/resources/resources/icons/gray-milling-machine.svg", QSize(), QIcon.Mode.Disabled, QIcon.State.On)
         self.tool_change_tb.setIcon(icon21)
         self.tool_change_tb.setIconSize(QSize(72, 72))
-        self.tool_change_tb.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
+        self.tool_change_tb.setToolButtonStyle(Qt.ToolButtonIconOnly)
 
         self.verticalLayout_3.addWidget(self.tool_change_tb)
 
@@ -2622,8 +2582,7 @@ class Ui_MainWindow(object):
         self.verticalLayout_14.setObjectName(u"verticalLayout_14")
         self.frame = QFrame(self.align_tab)
         self.frame.setObjectName(u"frame")
-        self.frame.setFrameShape(QFrame.Shape.StyledPanel)
-        self.frame.setFrameShadow(QFrame.Shadow.Raised)
+        self.frame.setFrameShape(QFrame.NoFrame)
         self.verticalLayout_13 = QVBoxLayout(self.frame)
         self.verticalLayout_13.setObjectName(u"verticalLayout_13")
         self.camera_la = QCameraLabel(self.frame)
@@ -2643,9 +2602,9 @@ class Ui_MainWindow(object):
         self.tool_or_camera_tb = QToolButton(self.frame)
         self.tool_or_camera_tb.setObjectName(u"tool_or_camera_tb")
         self.tool_or_camera_tb.setCheckable(True)
-        self.tool_or_camera_tb.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
+        self.tool_or_camera_tb.setToolButtonStyle(Qt.ToolButtonIconOnly)
 
-        self.gridLayout_28.addWidget(self.tool_or_camera_tb, 2, 1, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout_28.addWidget(self.tool_or_camera_tb, 2, 1, 1, 1)
 
         self.camera_list_cb = QComboBox(self.frame)
         self.camera_list_cb.setObjectName(u"camera_list_cb")
@@ -2678,27 +2637,26 @@ class Ui_MainWindow(object):
 
         self.verticalLayout_14.addWidget(self.frame)
 
-        self.verticalSpacer_3 = QSpacerItem(20, 20, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+        self.verticalSpacer_3 = QSpacerItem(20, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.verticalLayout_14.addItem(self.verticalSpacer_3)
 
         self.frame_2 = QFrame(self.align_tab)
         self.frame_2.setObjectName(u"frame_2")
-        self.frame_2.setFrameShape(QFrame.Shape.StyledPanel)
-        self.frame_2.setFrameShadow(QFrame.Shadow.Plain)
+        self.frame_2.setFrameShape(QFrame.NoFrame)
         self.frame_2.setLineWidth(1)
         self.frame_2.setMidLineWidth(1)
         self.horizontalLayout_23 = QHBoxLayout(self.frame_2)
         self.horizontalLayout_23.setObjectName(u"horizontalLayout_23")
         self.gridLayoutDirections_2 = QGridLayout()
         self.gridLayoutDirections_2.setObjectName(u"gridLayoutDirections_2")
-        self.gridLayoutDirections_2.setSizeConstraint(QLayout.SizeConstraint.SetFixedSize)
+        self.gridLayoutDirections_2.setSizeConstraint(QLayout.SetDefaultConstraint)
         self.gridLayoutDirections_2.setContentsMargins(0, 0, 0, 0)
         self.jog_layout_2 = QGridLayout()
         self.jog_layout_2.setObjectName(u"jog_layout_2")
         self.gridLayout_23 = QGridLayout()
         self.gridLayout_23.setObjectName(u"gridLayout_23")
-        self.gridLayout_23.setSizeConstraint(QLayout.SizeConstraint.SetDefaultConstraint)
+        self.gridLayout_23.setSizeConstraint(QLayout.SetDefaultConstraint)
         self.z_plus_pb_2 = QPushButton(self.frame_2)
         self.z_plus_pb_2.setObjectName(u"z_plus_pb_2")
         sizePolicy3.setHeightForWidth(self.z_plus_pb_2.sizePolicy().hasHeightForWidth())
@@ -2822,7 +2780,7 @@ class Ui_MainWindow(object):
         self.verticalLayout_19.setObjectName(u"verticalLayout_19")
         self.horizontalLayout_26 = QHBoxLayout()
         self.horizontalLayout_26.setObjectName(u"horizontalLayout_26")
-        self.horizontalLayout_26.setSizeConstraint(QLayout.SizeConstraint.SetDefaultConstraint)
+        self.horizontalLayout_26.setSizeConstraint(QLayout.SetDefaultConstraint)
         self.z_jog_l_4 = QLabel(self.frame_2)
         self.z_jog_l_4.setObjectName(u"z_jog_l_4")
         sizePolicy3.setHeightForWidth(self.z_jog_l_4.sizePolicy().hasHeightForWidth())
@@ -2830,9 +2788,8 @@ class Ui_MainWindow(object):
         self.z_jog_l_4.setMinimumSize(QSize(0, 20))
         self.z_jog_l_4.setMaximumSize(QSize(16777215, 23))
         self.z_jog_l_4.setFont(font)
-        self.z_jog_l_4.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
-        self.horizontalLayout_26.addWidget(self.z_jog_l_4, 0, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+        self.horizontalLayout_26.addWidget(self.z_jog_l_4)
 
         self.z_step_cb_2 = QComboBox(self.frame_2)
         self.z_step_cb_2.addItem("")
@@ -2850,7 +2807,7 @@ class Ui_MainWindow(object):
         self.z_step_cb_2.setMaximumSize(QSize(75, 16777215))
         self.z_step_cb_2.setFont(font)
 
-        self.horizontalLayout_26.addWidget(self.z_step_cb_2, 0, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+        self.horizontalLayout_26.addWidget(self.z_step_cb_2)
 
 
         self.verticalLayout_19.addLayout(self.horizontalLayout_26)
@@ -2862,8 +2819,7 @@ class Ui_MainWindow(object):
         self.z_step_val_dsb_2.setMinimumSize(QSize(70, 20))
         self.z_step_val_dsb_2.setMaximumSize(QSize(70, 16777215))
         self.z_step_val_dsb_2.setFont(font)
-        self.z_step_val_dsb_2.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.z_step_val_dsb_2.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+        self.z_step_val_dsb_2.setButtonSymbols(QAbstractSpinBox.UpDownArrows)
         self.z_step_val_dsb_2.setMinimum(0.010000000000000)
         self.z_step_val_dsb_2.setMaximum(1000.000000000000000)
         self.z_step_val_dsb_2.setSingleStep(0.100000000000000)
@@ -2925,16 +2881,15 @@ class Ui_MainWindow(object):
         self.verticalLayout_20.setObjectName(u"verticalLayout_20")
         self.horizontalLayout_27 = QHBoxLayout()
         self.horizontalLayout_27.setObjectName(u"horizontalLayout_27")
-        self.horizontalLayout_27.setSizeConstraint(QLayout.SizeConstraint.SetDefaultConstraint)
+        self.horizontalLayout_27.setSizeConstraint(QLayout.SetDefaultConstraint)
         self.xy_jog_l_2 = QLabel(self.frame_2)
         self.xy_jog_l_2.setObjectName(u"xy_jog_l_2")
         sizePolicy3.setHeightForWidth(self.xy_jog_l_2.sizePolicy().hasHeightForWidth())
         self.xy_jog_l_2.setSizePolicy(sizePolicy3)
         self.xy_jog_l_2.setMinimumSize(QSize(0, 0))
         self.xy_jog_l_2.setMaximumSize(QSize(16777215, 23))
-        self.xy_jog_l_2.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
-        self.horizontalLayout_27.addWidget(self.xy_jog_l_2, 0, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+        self.horizontalLayout_27.addWidget(self.xy_jog_l_2)
 
         self.xy_step_cb_2 = QComboBox(self.frame_2)
         self.xy_step_cb_2.addItem("")
@@ -2951,7 +2906,7 @@ class Ui_MainWindow(object):
         self.xy_step_cb_2.setMinimumSize(QSize(75, 0))
         self.xy_step_cb_2.setMaximumSize(QSize(75, 23))
 
-        self.horizontalLayout_27.addWidget(self.xy_step_cb_2, 0, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+        self.horizontalLayout_27.addWidget(self.xy_step_cb_2)
 
 
         self.verticalLayout_20.addLayout(self.horizontalLayout_27)
@@ -2987,8 +2942,7 @@ class Ui_MainWindow(object):
         self.xy_step_val_dsb_2.setMinimumSize(QSize(70, 23))
         self.xy_step_val_dsb_2.setMaximumSize(QSize(70, 23))
         self.xy_step_val_dsb_2.setFont(font)
-        self.xy_step_val_dsb_2.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.xy_step_val_dsb_2.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+        self.xy_step_val_dsb_2.setButtonSymbols(QAbstractSpinBox.UpDownArrows)
         self.xy_step_val_dsb_2.setMinimum(0.010000000000000)
         self.xy_step_val_dsb_2.setMaximum(1000.000000000000000)
         self.xy_step_val_dsb_2.setSingleStep(0.100000000000000)
@@ -3027,14 +2981,14 @@ class Ui_MainWindow(object):
         self.line_25 = QFrame(self.frame_2)
         self.line_25.setObjectName(u"line_25")
         self.line_25.setLineWidth(1)
-        self.line_25.setFrameShape(QFrame.Shape.HLine)
+        self.line_25.setFrameShape(QFrame.Shape.VLine)
         self.line_25.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.jog_layout_2.addWidget(self.line_25, 1, 1, 1, 1)
 
         self.line_26 = QFrame(self.frame_2)
         self.line_26.setObjectName(u"line_26")
-        self.line_26.setFrameShape(QFrame.Shape.HLine)
+        self.line_26.setFrameShape(QFrame.Shape.VLine)
         self.line_26.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.jog_layout_2.addWidget(self.line_26, 1, 0, 1, 1)
@@ -3054,12 +3008,10 @@ class Ui_MainWindow(object):
         self.z_axis_l_2.setMinimumSize(QSize(0, 12))
         self.z_axis_l_2.setMaximumSize(QSize(16777215, 13))
         self.z_axis_l_2.setFont(font)
-        self.z_axis_l_2.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
-        self.z_axis_l_2.setFrameShape(QFrame.Shape.NoFrame)
-        self.z_axis_l_2.setFrameShadow(QFrame.Shadow.Plain)
-        self.z_axis_l_2.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.z_axis_l_2.setLayoutDirection(Qt.LeftToRight)
+        self.z_axis_l_2.setFrameShape(QFrame.NoFrame)
 
-        self.droGridLayout_alignment.addWidget(self.z_axis_l_2, 0, 3, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.droGridLayout_alignment.addWidget(self.z_axis_l_2, 0, 3, 1, 1)
 
         self.mpos_y_l_2 = QLabel(self.frame_2)
         self.mpos_y_l_2.setObjectName(u"mpos_y_l_2")
@@ -3067,12 +3019,10 @@ class Ui_MainWindow(object):
         self.mpos_y_l_2.setSizePolicy(sizePolicy7)
         self.mpos_y_l_2.setMinimumSize(QSize(0, 12))
         self.mpos_y_l_2.setMaximumSize(QSize(16777215, 13))
-        self.mpos_y_l_2.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
-        self.mpos_y_l_2.setFrameShape(QFrame.Shape.NoFrame)
-        self.mpos_y_l_2.setFrameShadow(QFrame.Shadow.Plain)
-        self.mpos_y_l_2.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.mpos_y_l_2.setLayoutDirection(Qt.LeftToRight)
+        self.mpos_y_l_2.setFrameShape(QFrame.NoFrame)
 
-        self.droGridLayout_alignment.addWidget(self.mpos_y_l_2, 1, 2, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.droGridLayout_alignment.addWidget(self.mpos_y_l_2, 1, 2, 1, 1)
 
         self.x_axis_l_2 = QLabel(self.frame_2)
         self.x_axis_l_2.setObjectName(u"x_axis_l_2")
@@ -3081,12 +3031,10 @@ class Ui_MainWindow(object):
         self.x_axis_l_2.setMinimumSize(QSize(0, 12))
         self.x_axis_l_2.setMaximumSize(QSize(16777215, 13))
         self.x_axis_l_2.setFont(font)
-        self.x_axis_l_2.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
-        self.x_axis_l_2.setFrameShape(QFrame.Shape.NoFrame)
-        self.x_axis_l_2.setFrameShadow(QFrame.Shadow.Plain)
-        self.x_axis_l_2.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.x_axis_l_2.setLayoutDirection(Qt.LeftToRight)
+        self.x_axis_l_2.setFrameShape(QFrame.NoFrame)
 
-        self.droGridLayout_alignment.addWidget(self.x_axis_l_2, 0, 1, 1, 1, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+        self.droGridLayout_alignment.addWidget(self.x_axis_l_2, 0, 1, 1, 1)
 
         self.mpos_z_l_2 = QLabel(self.frame_2)
         self.mpos_z_l_2.setObjectName(u"mpos_z_l_2")
@@ -3094,12 +3042,10 @@ class Ui_MainWindow(object):
         self.mpos_z_l_2.setSizePolicy(sizePolicy7)
         self.mpos_z_l_2.setMinimumSize(QSize(0, 12))
         self.mpos_z_l_2.setMaximumSize(QSize(16777215, 13))
-        self.mpos_z_l_2.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
-        self.mpos_z_l_2.setFrameShape(QFrame.Shape.NoFrame)
-        self.mpos_z_l_2.setFrameShadow(QFrame.Shadow.Plain)
-        self.mpos_z_l_2.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.mpos_z_l_2.setLayoutDirection(Qt.LeftToRight)
+        self.mpos_z_l_2.setFrameShape(QFrame.NoFrame)
 
-        self.droGridLayout_alignment.addWidget(self.mpos_z_l_2, 1, 3, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.droGridLayout_alignment.addWidget(self.mpos_z_l_2, 1, 3, 1, 1)
 
         self.mpos_x_l_2 = QLabel(self.frame_2)
         self.mpos_x_l_2.setObjectName(u"mpos_x_l_2")
@@ -3107,12 +3053,10 @@ class Ui_MainWindow(object):
         self.mpos_x_l_2.setSizePolicy(sizePolicy7)
         self.mpos_x_l_2.setMinimumSize(QSize(0, 12))
         self.mpos_x_l_2.setMaximumSize(QSize(16777215, 13))
-        self.mpos_x_l_2.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
-        self.mpos_x_l_2.setFrameShape(QFrame.Shape.NoFrame)
-        self.mpos_x_l_2.setFrameShadow(QFrame.Shadow.Plain)
-        self.mpos_x_l_2.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.mpos_x_l_2.setLayoutDirection(Qt.LeftToRight)
+        self.mpos_x_l_2.setFrameShape(QFrame.NoFrame)
 
-        self.droGridLayout_alignment.addWidget(self.mpos_x_l_2, 1, 1, 1, 1, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+        self.droGridLayout_alignment.addWidget(self.mpos_x_l_2, 1, 1, 1, 1)
 
         self.wpos_l_2 = QLabel(self.frame_2)
         self.wpos_l_2.setObjectName(u"wpos_l_2")
@@ -3121,12 +3065,10 @@ class Ui_MainWindow(object):
         self.wpos_l_2.setMinimumSize(QSize(0, 12))
         self.wpos_l_2.setMaximumSize(QSize(16777215, 13))
         self.wpos_l_2.setFont(font)
-        self.wpos_l_2.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
-        self.wpos_l_2.setFrameShape(QFrame.Shape.NoFrame)
-        self.wpos_l_2.setFrameShadow(QFrame.Shadow.Plain)
-        self.wpos_l_2.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.wpos_l_2.setLayoutDirection(Qt.LeftToRight)
+        self.wpos_l_2.setFrameShape(QFrame.NoFrame)
 
-        self.droGridLayout_alignment.addWidget(self.wpos_l_2, 2, 0, 1, 1, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+        self.droGridLayout_alignment.addWidget(self.wpos_l_2, 2, 0, 1, 1)
 
         self.wpos_x_l_2 = QLabel(self.frame_2)
         self.wpos_x_l_2.setObjectName(u"wpos_x_l_2")
@@ -3134,12 +3076,10 @@ class Ui_MainWindow(object):
         self.wpos_x_l_2.setSizePolicy(sizePolicy7)
         self.wpos_x_l_2.setMinimumSize(QSize(0, 12))
         self.wpos_x_l_2.setMaximumSize(QSize(16777215, 13))
-        self.wpos_x_l_2.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
-        self.wpos_x_l_2.setFrameShape(QFrame.Shape.NoFrame)
-        self.wpos_x_l_2.setFrameShadow(QFrame.Shadow.Plain)
-        self.wpos_x_l_2.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.wpos_x_l_2.setLayoutDirection(Qt.LeftToRight)
+        self.wpos_x_l_2.setFrameShape(QFrame.NoFrame)
 
-        self.droGridLayout_alignment.addWidget(self.wpos_x_l_2, 2, 1, 1, 1, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+        self.droGridLayout_alignment.addWidget(self.wpos_x_l_2, 2, 1, 1, 1)
 
         self.mpos_l_2 = QLabel(self.frame_2)
         self.mpos_l_2.setObjectName(u"mpos_l_2")
@@ -3148,12 +3088,10 @@ class Ui_MainWindow(object):
         self.mpos_l_2.setMinimumSize(QSize(0, 12))
         self.mpos_l_2.setMaximumSize(QSize(16777215, 13))
         self.mpos_l_2.setFont(font)
-        self.mpos_l_2.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
-        self.mpos_l_2.setFrameShape(QFrame.Shape.NoFrame)
-        self.mpos_l_2.setFrameShadow(QFrame.Shadow.Plain)
-        self.mpos_l_2.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.mpos_l_2.setLayoutDirection(Qt.LeftToRight)
+        self.mpos_l_2.setFrameShape(QFrame.NoFrame)
 
-        self.droGridLayout_alignment.addWidget(self.mpos_l_2, 1, 0, 1, 1, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+        self.droGridLayout_alignment.addWidget(self.mpos_l_2, 1, 0, 1, 1)
 
         self.wpos_z_l_2 = QLabel(self.frame_2)
         self.wpos_z_l_2.setObjectName(u"wpos_z_l_2")
@@ -3161,12 +3099,10 @@ class Ui_MainWindow(object):
         self.wpos_z_l_2.setSizePolicy(sizePolicy7)
         self.wpos_z_l_2.setMinimumSize(QSize(0, 12))
         self.wpos_z_l_2.setMaximumSize(QSize(16777215, 13))
-        self.wpos_z_l_2.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
-        self.wpos_z_l_2.setFrameShape(QFrame.Shape.NoFrame)
-        self.wpos_z_l_2.setFrameShadow(QFrame.Shadow.Plain)
-        self.wpos_z_l_2.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.wpos_z_l_2.setLayoutDirection(Qt.LeftToRight)
+        self.wpos_z_l_2.setFrameShape(QFrame.NoFrame)
 
-        self.droGridLayout_alignment.addWidget(self.wpos_z_l_2, 2, 3, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.droGridLayout_alignment.addWidget(self.wpos_z_l_2, 2, 3, 1, 1)
 
         self.axis_l_2 = QLabel(self.frame_2)
         self.axis_l_2.setObjectName(u"axis_l_2")
@@ -3175,12 +3111,10 @@ class Ui_MainWindow(object):
         self.axis_l_2.setMinimumSize(QSize(0, 12))
         self.axis_l_2.setMaximumSize(QSize(16777215, 13))
         self.axis_l_2.setFont(font)
-        self.axis_l_2.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
-        self.axis_l_2.setFrameShape(QFrame.Shape.NoFrame)
-        self.axis_l_2.setFrameShadow(QFrame.Shadow.Plain)
-        self.axis_l_2.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.axis_l_2.setLayoutDirection(Qt.LeftToRight)
+        self.axis_l_2.setFrameShape(QFrame.NoFrame)
 
-        self.droGridLayout_alignment.addWidget(self.axis_l_2, 0, 0, 1, 1, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+        self.droGridLayout_alignment.addWidget(self.axis_l_2, 0, 0, 1, 1)
 
         self.y_axis_l_2 = QLabel(self.frame_2)
         self.y_axis_l_2.setObjectName(u"y_axis_l_2")
@@ -3189,12 +3123,10 @@ class Ui_MainWindow(object):
         self.y_axis_l_2.setMinimumSize(QSize(0, 12))
         self.y_axis_l_2.setMaximumSize(QSize(16777215, 13))
         self.y_axis_l_2.setFont(font)
-        self.y_axis_l_2.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
-        self.y_axis_l_2.setFrameShape(QFrame.Shape.NoFrame)
-        self.y_axis_l_2.setFrameShadow(QFrame.Shadow.Plain)
-        self.y_axis_l_2.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.y_axis_l_2.setLayoutDirection(Qt.LeftToRight)
+        self.y_axis_l_2.setFrameShape(QFrame.NoFrame)
 
-        self.droGridLayout_alignment.addWidget(self.y_axis_l_2, 0, 2, 1, 1, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+        self.droGridLayout_alignment.addWidget(self.y_axis_l_2, 0, 2, 1, 1)
 
         self.wpos_y_l_2 = QLabel(self.frame_2)
         self.wpos_y_l_2.setObjectName(u"wpos_y_l_2")
@@ -3202,12 +3134,10 @@ class Ui_MainWindow(object):
         self.wpos_y_l_2.setSizePolicy(sizePolicy7)
         self.wpos_y_l_2.setMinimumSize(QSize(0, 12))
         self.wpos_y_l_2.setMaximumSize(QSize(16777215, 13))
-        self.wpos_y_l_2.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
-        self.wpos_y_l_2.setFrameShape(QFrame.Shape.NoFrame)
-        self.wpos_y_l_2.setFrameShadow(QFrame.Shadow.Plain)
-        self.wpos_y_l_2.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.wpos_y_l_2.setLayoutDirection(Qt.LeftToRight)
+        self.wpos_y_l_2.setFrameShape(QFrame.NoFrame)
 
-        self.droGridLayout_alignment.addWidget(self.wpos_y_l_2, 2, 2, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.droGridLayout_alignment.addWidget(self.wpos_y_l_2, 2, 2, 1, 1)
 
 
         self.gridLayoutDirections_2.addLayout(self.droGridLayout_alignment, 0, 0, 1, 1)
@@ -3218,7 +3148,7 @@ class Ui_MainWindow(object):
 
         self.verticalLayout_14.addWidget(self.frame_2)
 
-        self.verticalSpacer_9 = QSpacerItem(20, 26, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
+        self.verticalSpacer_9 = QSpacerItem(20, 26, QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Minimum)
 
         self.verticalLayout_14.addItem(self.verticalSpacer_9)
 
@@ -3239,7 +3169,7 @@ class Ui_MainWindow(object):
         self.flip_horizontally_tb.setMinimumSize(QSize(0, 20))
         self.flip_horizontally_tb.setMaximumSize(QSize(16777215, 20))
         self.flip_horizontally_tb.setCheckable(True)
-        self.flip_horizontally_tb.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
+        self.flip_horizontally_tb.setToolButtonStyle(Qt.ToolButtonIconOnly)
 
         self.horizontalLayout_28.addWidget(self.flip_horizontally_tb)
 
@@ -3248,7 +3178,7 @@ class Ui_MainWindow(object):
         self.flip_vertically_tb.setMinimumSize(QSize(0, 20))
         self.flip_vertically_tb.setMaximumSize(QSize(16777215, 20))
         self.flip_vertically_tb.setCheckable(True)
-        self.flip_vertically_tb.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
+        self.flip_vertically_tb.setToolButtonStyle(Qt.ToolButtonIconOnly)
 
         self.horizontalLayout_28.addWidget(self.flip_vertically_tb)
 
@@ -3282,12 +3212,12 @@ class Ui_MainWindow(object):
         self.align_points_tw.setSizePolicy(sizePolicy)
         self.align_points_tw.setMinimumSize(QSize(200, 0))
         self.align_points_tw.setMaximumSize(QSize(500, 16777215))
-        self.align_points_tw.setSizeAdjustPolicy(QAbstractScrollArea.SizeAdjustPolicy.AdjustToContents)
+        self.align_points_tw.setSizeAdjustPolicy(QAbstractScrollArea.AdjustIgnored)
         self.align_points_tw.setColumnCount(4)
         self.align_points_tw.horizontalHeader().setCascadingSectionResizes(False)
         self.align_points_tw.horizontalHeader().setDefaultSectionSize(100)
 
-        self.verticalLayout_22.addWidget(self.align_points_tw, 0, Qt.AlignmentFlag.AlignHCenter)
+        self.verticalLayout_22.addWidget(self.align_points_tw)
 
         self.horizontalLayout_29 = QHBoxLayout()
         self.horizontalLayout_29.setObjectName(u"horizontalLayout_29")
@@ -3301,7 +3231,7 @@ class Ui_MainWindow(object):
         icon22 = QIcon()
         icon22.addFile(u":/resources/resources/icons/gray-refresh.svg", QSize(), QIcon.Mode.Normal, QIcon.State.Off)
         self.add_point_tb.setIcon(icon22)
-        self.add_point_tb.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
+        self.add_point_tb.setToolButtonStyle(Qt.ToolButtonIconOnly)
 
         self.horizontalLayout_29.addWidget(self.add_point_tb)
 
@@ -3311,7 +3241,7 @@ class Ui_MainWindow(object):
         self.remove_point_tb.setSizePolicy(sizePolicy3)
         self.remove_point_tb.setMinimumSize(QSize(50, 50))
         self.remove_point_tb.setFont(font3)
-        self.remove_point_tb.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
+        self.remove_point_tb.setToolButtonStyle(Qt.ToolButtonIconOnly)
 
         self.horizontalLayout_29.addWidget(self.remove_point_tb)
 
@@ -3324,7 +3254,7 @@ class Ui_MainWindow(object):
         self.apply_alignment_tb.setMinimumSize(QSize(50, 50))
         self.apply_alignment_tb.setIcon(icon14)
         self.apply_alignment_tb.setCheckable(True)
-        self.apply_alignment_tb.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
+        self.apply_alignment_tb.setToolButtonStyle(Qt.ToolButtonIconOnly)
 
         self.horizontalLayout_29.addWidget(self.apply_alignment_tb)
 
@@ -3342,9 +3272,8 @@ class Ui_MainWindow(object):
         self.label_17.setSizePolicy(sizePolicy3)
         self.label_17.setMinimumSize(QSize(0, 20))
         self.label_17.setMaximumSize(QSize(16777215, 20))
-        self.label_17.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
-        self.horizontalLayout_30.addWidget(self.label_17, 0, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+        self.horizontalLayout_30.addWidget(self.label_17)
 
         self.horizontalSpacer_15 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
@@ -3359,9 +3288,8 @@ class Ui_MainWindow(object):
         self.label_18.setSizePolicy(sizePolicy15)
         self.label_18.setMinimumSize(QSize(0, 20))
         self.label_18.setMaximumSize(QSize(16777215, 20))
-        self.label_18.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
-        self.horizontalLayout_30.addWidget(self.label_18, 0, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+        self.horizontalLayout_30.addWidget(self.label_18)
 
 
         self.verticalLayout_21.addLayout(self.horizontalLayout_30)
@@ -3390,6 +3318,87 @@ class Ui_MainWindow(object):
         self.application_settings_tab.setObjectName(u"application_settings_tab")
         self.gridLayout_9 = QGridLayout(self.application_settings_tab)
         self.gridLayout_9.setObjectName(u"gridLayout_9")
+        self.verticalSpacer_12 = QSpacerItem(20, 10, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+
+        self.gridLayout_9.addItem(self.verticalSpacer_12, 5, 0, 1, 1)
+
+        self.horizontalSpacer_3 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.gridLayout_9.addItem(self.horizontalSpacer_3, 1, 1, 2, 1)
+
+        self.gridLayout_10 = QGridLayout()
+        self.gridLayout_10.setObjectName(u"gridLayout_10")
+        self.allignment_drill_diameter_la_2 = QLabel(self.application_settings_tab)
+        self.allignment_drill_diameter_la_2.setObjectName(u"allignment_drill_diameter_la_2")
+        sizePolicy3.setHeightForWidth(self.allignment_drill_diameter_la_2.sizePolicy().hasHeightForWidth())
+        self.allignment_drill_diameter_la_2.setSizePolicy(sizePolicy3)
+        self.allignment_drill_diameter_la_2.setMinimumSize(QSize(200, 0))
+        self.allignment_drill_diameter_la_2.setMaximumSize(QSize(130, 16777215))
+        self.allignment_drill_diameter_la_2.setFont(font)
+        self.allignment_drill_diameter_la_2.setLocale(QLocale(QLocale.English, QLocale.UnitedKingdom))
+
+        self.gridLayout_10.addWidget(self.allignment_drill_diameter_la_2, 0, 0, 1, 1)
+
+        self.serial_error_warning_threshold_sb = QSpinBox(self.application_settings_tab)
+        self.serial_error_warning_threshold_sb.setObjectName(u"serial_error_warning_threshold_sb")
+        sizePolicy3.setHeightForWidth(self.serial_error_warning_threshold_sb.sizePolicy().hasHeightForWidth())
+        self.serial_error_warning_threshold_sb.setSizePolicy(sizePolicy3)
+        self.serial_error_warning_threshold_sb.setMinimumSize(QSize(252, 0))
+        self.serial_error_warning_threshold_sb.setMaximumSize(QSize(252, 16777215))
+        self.serial_error_warning_threshold_sb.setFont(font)
+        self.serial_error_warning_threshold_sb.setLocale(QLocale(QLocale.English, QLocale.UnitedKingdom))
+        self.serial_error_warning_threshold_sb.setButtonSymbols(QAbstractSpinBox.UpDownArrows)
+        self.serial_error_warning_threshold_sb.setValue(3)
+
+        self.gridLayout_10.addWidget(self.serial_error_warning_threshold_sb, 0, 1, 1, 1)
+
+        self.allignment_drill_diameter_la_3 = QLabel(self.application_settings_tab)
+        self.allignment_drill_diameter_la_3.setObjectName(u"allignment_drill_diameter_la_3")
+        sizePolicy3.setHeightForWidth(self.allignment_drill_diameter_la_3.sizePolicy().hasHeightForWidth())
+        self.allignment_drill_diameter_la_3.setSizePolicy(sizePolicy3)
+        self.allignment_drill_diameter_la_3.setMinimumSize(QSize(200, 0))
+        self.allignment_drill_diameter_la_3.setMaximumSize(QSize(130, 16777215))
+        self.allignment_drill_diameter_la_3.setFont(font)
+        self.allignment_drill_diameter_la_3.setLocale(QLocale(QLocale.English, QLocale.UnitedKingdom))
+
+        self.gridLayout_10.addWidget(self.allignment_drill_diameter_la_3, 1, 0, 1, 1)
+
+        self.serial_error_critical_threshold_sb = QSpinBox(self.application_settings_tab)
+        self.serial_error_critical_threshold_sb.setObjectName(u"serial_error_critical_threshold_sb")
+        sizePolicy3.setHeightForWidth(self.serial_error_critical_threshold_sb.sizePolicy().hasHeightForWidth())
+        self.serial_error_critical_threshold_sb.setSizePolicy(sizePolicy3)
+        self.serial_error_critical_threshold_sb.setMinimumSize(QSize(252, 0))
+        self.serial_error_critical_threshold_sb.setMaximumSize(QSize(252, 16777215))
+        self.serial_error_critical_threshold_sb.setFont(font)
+        self.serial_error_critical_threshold_sb.setLocale(QLocale(QLocale.English, QLocale.UnitedKingdom))
+        self.serial_error_critical_threshold_sb.setButtonSymbols(QAbstractSpinBox.UpDownArrows)
+        self.serial_error_critical_threshold_sb.setValue(10)
+
+        self.gridLayout_10.addWidget(self.serial_error_critical_threshold_sb, 1, 1, 1, 1)
+
+
+        self.gridLayout_9.addLayout(self.gridLayout_10, 7, 0, 1, 1)
+
+        self.layer_colors_section_la = QLabel(self.application_settings_tab)
+        self.layer_colors_section_la.setObjectName(u"layer_colors_section_la")
+        sizePolicy3.setHeightForWidth(self.layer_colors_section_la.sizePolicy().hasHeightForWidth())
+        self.layer_colors_section_la.setSizePolicy(sizePolicy3)
+        self.layer_colors_section_la.setMinimumSize(QSize(210, 0))
+        self.layer_colors_section_la.setMaximumSize(QSize(300, 20))
+        font4 = QFont()
+        font4.setPointSize(12)
+        font4.setBold(True)
+        self.layer_colors_section_la.setFont(font4)
+
+        self.gridLayout_9.addWidget(self.layer_colors_section_la, 0, 0, 1, 1)
+
+        self.line_17 = QFrame(self.application_settings_tab)
+        self.line_17.setObjectName(u"line_17")
+        self.line_17.setFrameShape(QFrame.Shape.HLine)
+        self.line_17.setFrameShadow(QFrame.Shadow.Sunken)
+
+        self.gridLayout_9.addWidget(self.line_17, 4, 0, 1, 1)
+
         self.gridLayout_12 = QGridLayout()
         self.gridLayout_12.setObjectName(u"gridLayout_12")
         self.top_layer_color_pb = QPushButton(self.application_settings_tab)
@@ -3405,7 +3414,7 @@ class Ui_MainWindow(object):
         self.bottom_layer_color_la = QLabel(self.application_settings_tab)
         self.bottom_layer_color_la.setObjectName(u"bottom_layer_color_la")
         self.bottom_layer_color_la.setMinimumSize(QSize(150, 0))
-        self.bottom_layer_color_la.setFrameShape(QFrame.Shape.WinPanel)
+        self.bottom_layer_color_la.setFrameShape(QFrame.NoFrame)
 
         self.gridLayout_12.addWidget(self.bottom_layer_color_la, 1, 1, 1, 1)
 
@@ -3422,7 +3431,7 @@ class Ui_MainWindow(object):
         self.top_layer_color_la = QLabel(self.application_settings_tab)
         self.top_layer_color_la.setObjectName(u"top_layer_color_la")
         self.top_layer_color_la.setMinimumSize(QSize(150, 0))
-        self.top_layer_color_la.setFrameShape(QFrame.Shape.WinPanel)
+        self.top_layer_color_la.setFrameShape(QFrame.NoFrame)
 
         self.gridLayout_12.addWidget(self.top_layer_color_la, 0, 1, 1, 1)
 
@@ -3439,69 +3448,51 @@ class Ui_MainWindow(object):
         self.profile_layer_color_la = QLabel(self.application_settings_tab)
         self.profile_layer_color_la.setObjectName(u"profile_layer_color_la")
         self.profile_layer_color_la.setMinimumSize(QSize(150, 0))
-        self.profile_layer_color_la.setFrameShape(QFrame.Shape.WinPanel)
+        self.profile_layer_color_la.setFrameShape(QFrame.NoFrame)
 
         self.gridLayout_12.addWidget(self.profile_layer_color_la, 2, 1, 1, 1)
 
         self.drill_layer_color_la = QLabel(self.application_settings_tab)
         self.drill_layer_color_la.setObjectName(u"drill_layer_color_la")
         self.drill_layer_color_la.setMinimumSize(QSize(150, 0))
-        self.drill_layer_color_la.setFrameShape(QFrame.Shape.WinPanel)
+        self.drill_layer_color_la.setFrameShape(QFrame.NoFrame)
 
         self.gridLayout_12.addWidget(self.drill_layer_color_la, 3, 1, 1, 1)
 
         self.nc_top_layer_color_la = QLabel(self.application_settings_tab)
         self.nc_top_layer_color_la.setObjectName(u"nc_top_layer_color_la")
         self.nc_top_layer_color_la.setMinimumSize(QSize(150, 0))
-        self.nc_top_layer_color_la.setFrameShape(QFrame.Shape.WinPanel)
+        self.nc_top_layer_color_la.setFrameShape(QFrame.NoFrame)
 
         self.gridLayout_12.addWidget(self.nc_top_layer_color_la, 4, 1, 1, 1)
 
         self.nc_bottom_layer_color_la = QLabel(self.application_settings_tab)
         self.nc_bottom_layer_color_la.setObjectName(u"nc_bottom_layer_color_la")
         self.nc_bottom_layer_color_la.setMinimumSize(QSize(150, 0))
-        self.nc_bottom_layer_color_la.setFrameShape(QFrame.Shape.WinPanel)
+        self.nc_bottom_layer_color_la.setFrameShape(QFrame.NoFrame)
 
         self.gridLayout_12.addWidget(self.nc_bottom_layer_color_la, 5, 1, 1, 1)
 
 
-        self.gridLayout_9.addLayout(self.gridLayout_12, 3, 0, 1, 1)
+        self.gridLayout_9.addLayout(self.gridLayout_12, 1, 0, 1, 1)
 
-        self.line_17 = QFrame(self.application_settings_tab)
-        self.line_17.setObjectName(u"line_17")
-        self.line_17.setFrameShape(QFrame.Shape.HLine)
-        self.line_17.setFrameShadow(QFrame.Shadow.Sunken)
+        self.layer_colors_section_la_2 = QLabel(self.application_settings_tab)
+        self.layer_colors_section_la_2.setObjectName(u"layer_colors_section_la_2")
+        sizePolicy3.setHeightForWidth(self.layer_colors_section_la_2.sizePolicy().hasHeightForWidth())
+        self.layer_colors_section_la_2.setSizePolicy(sizePolicy3)
+        self.layer_colors_section_la_2.setMinimumSize(QSize(210, 0))
+        self.layer_colors_section_la_2.setMaximumSize(QSize(300, 20))
+        self.layer_colors_section_la_2.setFont(font4)
 
-        self.gridLayout_9.addWidget(self.line_17, 2, 0, 1, 1)
+        self.gridLayout_9.addWidget(self.layer_colors_section_la_2, 6, 0, 1, 1)
 
-        self.verticalSpacer_2 = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+        self.verticalSpacer_2 = QSpacerItem(20, 40, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
-        self.gridLayout_9.addItem(self.verticalSpacer_2, 4, 0, 1, 1)
+        self.gridLayout_9.addItem(self.verticalSpacer_2, 8, 0, 1, 1)
 
-        self.layer_colors_section_la = QLabel(self.application_settings_tab)
-        self.layer_colors_section_la.setObjectName(u"layer_colors_section_la")
-        sizePolicy3.setHeightForWidth(self.layer_colors_section_la.sizePolicy().hasHeightForWidth())
-        self.layer_colors_section_la.setSizePolicy(sizePolicy3)
-        self.layer_colors_section_la.setMinimumSize(QSize(210, 0))
-        self.layer_colors_section_la.setMaximumSize(QSize(300, 20))
-        font4 = QFont()
-        font4.setPointSize(12)
-        font4.setBold(True)
-        self.layer_colors_section_la.setFont(font4)
-        self.layer_colors_section_la.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.verticalSpacer_13 = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
-        self.gridLayout_9.addWidget(self.layer_colors_section_la, 1, 0, 1, 1)
-
-        self.horizontalSpacer_3 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.gridLayout_9.addItem(self.horizontalSpacer_3, 3, 1, 1, 1)
-
-        self.line_18 = QFrame(self.application_settings_tab)
-        self.line_18.setObjectName(u"line_18")
-        self.line_18.setFrameShape(QFrame.Shape.HLine)
-        self.line_18.setFrameShadow(QFrame.Shadow.Sunken)
-
-        self.gridLayout_9.addWidget(self.line_18, 0, 0, 1, 1)
+        self.gridLayout_9.addItem(self.verticalSpacer_13, 3, 0, 1, 1)
 
         self.settings_sub_tab.addTab(self.application_settings_tab, "")
         self.jobs_machine_settings_tab = QWidget()
@@ -3510,7 +3501,7 @@ class Ui_MainWindow(object):
         self.gridLayout_13.setObjectName(u"gridLayout_13")
         self.gridLayout_20 = QGridLayout()
         self.gridLayout_20.setObjectName(u"gridLayout_20")
-        self.gridLayout_20.setSizeConstraint(QLayout.SizeConstraint.SetFixedSize)
+        self.gridLayout_20.setSizeConstraint(QLayout.SetDefaultConstraint)
         self.x_axis_la = QLabel(self.jobs_machine_settings_tab)
         self.x_axis_la.setObjectName(u"x_axis_la")
         sizePolicy3.setHeightForWidth(self.x_axis_la.sizePolicy().hasHeightForWidth())
@@ -3520,7 +3511,7 @@ class Ui_MainWindow(object):
         self.x_axis_la.setFont(font)
         self.x_axis_la.setLocale(QLocale(QLocale.English, QLocale.UnitedKingdom))
 
-        self.gridLayout_20.addWidget(self.x_axis_la, 0, 1, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout_20.addWidget(self.x_axis_la, 0, 1, 1, 1)
 
         self.x_la_2 = QLabel(self.jobs_machine_settings_tab)
         self.x_la_2.setObjectName(u"x_la_2")
@@ -3531,7 +3522,7 @@ class Ui_MainWindow(object):
         self.x_la_2.setFont(font)
         self.x_la_2.setLocale(QLocale(QLocale.English, QLocale.UnitedKingdom))
 
-        self.gridLayout_20.addWidget(self.x_la_2, 0, 2, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout_20.addWidget(self.x_la_2, 0, 2, 1, 1)
 
         self.mirroring_axis_la = QLabel(self.jobs_machine_settings_tab)
         self.mirroring_axis_la.setObjectName(u"mirroring_axis_la")
@@ -3542,7 +3533,7 @@ class Ui_MainWindow(object):
         self.mirroring_axis_la.setFont(font)
         self.mirroring_axis_la.setLocale(QLocale(QLocale.English, QLocale.UnitedKingdom))
 
-        self.gridLayout_20.addWidget(self.mirroring_axis_la, 1, 0, 1, 1, Qt.AlignmentFlag.AlignLeft|Qt.AlignmentFlag.AlignVCenter)
+        self.gridLayout_20.addWidget(self.mirroring_axis_la, 1, 0, 1, 1)
 
         self.x_mirror_rb = QRadioButton(self.jobs_machine_settings_tab)
         self.x_mirror_rb.setObjectName(u"x_mirror_rb")
@@ -3550,7 +3541,7 @@ class Ui_MainWindow(object):
         self.x_mirror_rb.setSizePolicy(sizePolicy3)
         self.x_mirror_rb.setMaximumSize(QSize(120, 20))
 
-        self.gridLayout_20.addWidget(self.x_mirror_rb, 1, 1, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout_20.addWidget(self.x_mirror_rb, 1, 1, 1, 1)
 
         self.y_mirror_rb = QRadioButton(self.jobs_machine_settings_tab)
         self.y_mirror_rb.setObjectName(u"y_mirror_rb")
@@ -3558,7 +3549,7 @@ class Ui_MainWindow(object):
         self.y_mirror_rb.setSizePolicy(sizePolicy3)
         self.y_mirror_rb.setMaximumSize(QSize(120, 20))
 
-        self.gridLayout_20.addWidget(self.y_mirror_rb, 1, 2, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout_20.addWidget(self.y_mirror_rb, 1, 2, 1, 1)
 
         self.horizontalSpacer_9 = QSpacerItem(130, 20, QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Minimum)
 
@@ -3573,19 +3564,19 @@ class Ui_MainWindow(object):
         self.probe_settings_section_la.setSizePolicy(sizePolicy3)
         self.probe_settings_section_la.setFont(font4)
 
-        self.gridLayout_13.addWidget(self.probe_settings_section_la, 7, 0, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout_13.addWidget(self.probe_settings_section_la, 7, 0, 1, 1)
 
-        self.verticalSpacer_6 = QSpacerItem(20, 10, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+        self.verticalSpacer_6 = QSpacerItem(20, 10, QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Minimum)
 
         self.gridLayout_13.addItem(self.verticalSpacer_6, 10, 0, 1, 1)
 
-        self.verticalSpacer_8 = QSpacerItem(20, 10, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+        self.verticalSpacer_8 = QSpacerItem(20, 10, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.gridLayout_13.addItem(self.verticalSpacer_8, 21, 0, 1, 1)
 
         self.line_10 = QFrame(self.jobs_machine_settings_tab)
         self.line_10.setObjectName(u"line_10")
-        self.line_10.setFrameShape(QFrame.Shape.HLine)
+        self.line_10.setFrameShape(QFrame.Shape.VLine)
         self.line_10.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.gridLayout_13.addWidget(self.line_10, 19, 0, 1, 1)
@@ -3596,9 +3587,9 @@ class Ui_MainWindow(object):
         self.tool_change_section_la.setSizePolicy(sizePolicy3)
         self.tool_change_section_la.setFont(font4)
 
-        self.gridLayout_13.addWidget(self.tool_change_section_la, 12, 0, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout_13.addWidget(self.tool_change_section_la, 12, 0, 1, 1)
 
-        self.verticalSpacer_5 = QSpacerItem(20, 10, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+        self.verticalSpacer_5 = QSpacerItem(20, 10, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.gridLayout_13.addItem(self.verticalSpacer_5, 5, 0, 1, 1)
 
@@ -3610,16 +3601,16 @@ class Ui_MainWindow(object):
         self.jobs_common_settings_section_la.setMaximumSize(QSize(300, 20))
         self.jobs_common_settings_section_la.setFont(font4)
 
-        self.gridLayout_13.addWidget(self.jobs_common_settings_section_la, 1, 0, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout_13.addWidget(self.jobs_common_settings_section_la, 1, 0, 1, 1)
 
         self.line_16 = QFrame(self.jobs_machine_settings_tab)
         self.line_16.setObjectName(u"line_16")
-        self.line_16.setFrameShape(QFrame.Shape.HLine)
+        self.line_16.setFrameShape(QFrame.Shape.VLine)
         self.line_16.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.gridLayout_13.addWidget(self.line_16, 6, 0, 1, 1)
 
-        self.horizontalSpacer_4 = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.horizontalSpacer_4 = QSpacerItem(40, 20, QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Minimum)
 
         self.gridLayout_13.addItem(self.horizontalSpacer_4, 14, 1, 1, 1)
 
@@ -3632,8 +3623,7 @@ class Ui_MainWindow(object):
         self.feedrate_z_dsb.setMaximumSize(QSize(252, 16777215))
         self.feedrate_z_dsb.setFont(font)
         self.feedrate_z_dsb.setLocale(QLocale(QLocale.English, QLocale.UnitedKingdom))
-        self.feedrate_z_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.feedrate_z_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.UpDownArrows)
+        self.feedrate_z_dsb.setButtonSymbols(QAbstractSpinBox.UpDownArrows)
         self.feedrate_z_dsb.setMaximum(100000.000000000000000)
         self.feedrate_z_dsb.setSingleStep(1.000000000000000)
 
@@ -3669,8 +3659,7 @@ class Ui_MainWindow(object):
         self.feedrate_xy_dsb.setMaximumSize(QSize(252, 16777215))
         self.feedrate_xy_dsb.setFont(font)
         self.feedrate_xy_dsb.setLocale(QLocale(QLocale.English, QLocale.UnitedKingdom))
-        self.feedrate_xy_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.feedrate_xy_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.UpDownArrows)
+        self.feedrate_xy_dsb.setButtonSymbols(QAbstractSpinBox.UpDownArrows)
         self.feedrate_xy_dsb.setMaximum(100000.000000000000000)
         self.feedrate_xy_dsb.setSingleStep(1.000000000000000)
 
@@ -3682,8 +3671,7 @@ class Ui_MainWindow(object):
         self.feedrate_probe_dsb.setMaximumSize(QSize(252, 16777215))
         self.feedrate_probe_dsb.setFont(font)
         self.feedrate_probe_dsb.setLocale(QLocale(QLocale.English, QLocale.UnitedKingdom))
-        self.feedrate_probe_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.feedrate_probe_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.UpDownArrows)
+        self.feedrate_probe_dsb.setButtonSymbols(QAbstractSpinBox.UpDownArrows)
         self.feedrate_probe_dsb.setMaximum(100000.000000000000000)
         self.feedrate_probe_dsb.setSingleStep(1.000000000000000)
 
@@ -3718,12 +3706,12 @@ class Ui_MainWindow(object):
         self.verticalLayout_5 = QVBoxLayout()
         self.verticalLayout_5.setSpacing(2)
         self.verticalLayout_5.setObjectName(u"verticalLayout_5")
-        self.verticalLayout_5.setSizeConstraint(QLayout.SizeConstraint.SetFixedSize)
+        self.verticalLayout_5.setSizeConstraint(QLayout.SetDefaultConstraint)
         self.horizontalLayout_13 = QHBoxLayout()
         self.horizontalLayout_13.setObjectName(u"horizontalLayout_13")
         self.gridLayout_14 = QGridLayout()
         self.gridLayout_14.setObjectName(u"gridLayout_14")
-        self.gridLayout_14.setSizeConstraint(QLayout.SizeConstraint.SetDefaultConstraint)
+        self.gridLayout_14.setSizeConstraint(QLayout.SetDefaultConstraint)
         self.gridLayout_14.setVerticalSpacing(2)
         self.tool_probe_y_wpos_dsb = QDoubleSpinBox(self.jobs_machine_settings_tab)
         self.tool_probe_y_wpos_dsb.setObjectName(u"tool_probe_y_wpos_dsb")
@@ -3732,8 +3720,7 @@ class Ui_MainWindow(object):
         self.tool_probe_y_wpos_dsb.setMinimumSize(QSize(80, 20))
         self.tool_probe_y_wpos_dsb.setMaximumSize(QSize(80, 16777215))
         self.tool_probe_y_wpos_dsb.setFont(font)
-        self.tool_probe_y_wpos_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.tool_probe_y_wpos_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+        self.tool_probe_y_wpos_dsb.setButtonSymbols(QAbstractSpinBox.UpDownArrows)
         self.tool_probe_y_wpos_dsb.setMinimum(-1000.000000000000000)
         self.tool_probe_y_wpos_dsb.setMaximum(1000.000000000000000)
         self.tool_probe_y_wpos_dsb.setSingleStep(0.100000000000000)
@@ -3747,8 +3734,7 @@ class Ui_MainWindow(object):
         self.tool_probe_y_mpos_dsb.setMinimumSize(QSize(80, 20))
         self.tool_probe_y_mpos_dsb.setMaximumSize(QSize(80, 16777215))
         self.tool_probe_y_mpos_dsb.setFont(font)
-        self.tool_probe_y_mpos_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.tool_probe_y_mpos_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+        self.tool_probe_y_mpos_dsb.setButtonSymbols(QAbstractSpinBox.UpDownArrows)
         self.tool_probe_y_mpos_dsb.setMinimum(-1000.000000000000000)
         self.tool_probe_y_mpos_dsb.setMaximum(1000.000000000000000)
         self.tool_probe_y_mpos_dsb.setSingleStep(0.100000000000000)
@@ -3763,7 +3749,7 @@ class Ui_MainWindow(object):
         self.x_la.setFont(font)
         self.x_la.setLocale(QLocale(QLocale.English, QLocale.UnitedKingdom))
 
-        self.gridLayout_14.addWidget(self.x_la, 0, 1, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout_14.addWidget(self.x_la, 0, 1, 1, 1)
 
         self.y_la = QLabel(self.jobs_machine_settings_tab)
         self.y_la.setObjectName(u"y_la")
@@ -3773,7 +3759,7 @@ class Ui_MainWindow(object):
         self.y_la.setFont(font)
         self.y_la.setLocale(QLocale(QLocale.English, QLocale.UnitedKingdom))
 
-        self.gridLayout_14.addWidget(self.y_la, 0, 2, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout_14.addWidget(self.y_la, 0, 2, 1, 1)
 
         self.tool_probe_z_limit_dsb = QDoubleSpinBox(self.jobs_machine_settings_tab)
         self.tool_probe_z_limit_dsb.setObjectName(u"tool_probe_z_limit_dsb")
@@ -3783,8 +3769,7 @@ class Ui_MainWindow(object):
         self.tool_probe_z_limit_dsb.setMaximumSize(QSize(80, 16777215))
         self.tool_probe_z_limit_dsb.setFont(font)
         self.tool_probe_z_limit_dsb.setLocale(QLocale(QLocale.English, QLocale.UnitedKingdom))
-        self.tool_probe_z_limit_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.tool_probe_z_limit_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+        self.tool_probe_z_limit_dsb.setButtonSymbols(QAbstractSpinBox.UpDownArrows)
         self.tool_probe_z_limit_dsb.setMinimum(-1000.000000000000000)
         self.tool_probe_z_limit_dsb.setMaximum(1000.000000000000000)
         self.tool_probe_z_limit_dsb.setSingleStep(0.100000000000000)
@@ -3798,8 +3783,7 @@ class Ui_MainWindow(object):
         self.tool_probe_x_wpos_dsb.setMinimumSize(QSize(80, 20))
         self.tool_probe_x_wpos_dsb.setMaximumSize(QSize(80, 16777215))
         self.tool_probe_x_wpos_dsb.setFont(font)
-        self.tool_probe_x_wpos_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.tool_probe_x_wpos_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+        self.tool_probe_x_wpos_dsb.setButtonSymbols(QAbstractSpinBox.UpDownArrows)
         self.tool_probe_x_wpos_dsb.setMinimum(-1000.000000000000000)
         self.tool_probe_x_wpos_dsb.setMaximum(1000.000000000000000)
         self.tool_probe_x_wpos_dsb.setSingleStep(0.100000000000000)
@@ -3814,7 +3798,7 @@ class Ui_MainWindow(object):
         self.z_la.setFont(font)
         self.z_la.setLocale(QLocale(QLocale.English, QLocale.UnitedKingdom))
 
-        self.gridLayout_14.addWidget(self.z_la, 0, 3, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout_14.addWidget(self.z_la, 0, 3, 1, 1)
 
         self.tool_probe_x_mpos_dsb = QDoubleSpinBox(self.jobs_machine_settings_tab)
         self.tool_probe_x_mpos_dsb.setObjectName(u"tool_probe_x_mpos_dsb")
@@ -3823,8 +3807,7 @@ class Ui_MainWindow(object):
         self.tool_probe_x_mpos_dsb.setMinimumSize(QSize(80, 20))
         self.tool_probe_x_mpos_dsb.setMaximumSize(QSize(80, 16777215))
         self.tool_probe_x_mpos_dsb.setFont(font)
-        self.tool_probe_x_mpos_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.tool_probe_x_mpos_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+        self.tool_probe_x_mpos_dsb.setButtonSymbols(QAbstractSpinBox.UpDownArrows)
         self.tool_probe_x_mpos_dsb.setMinimum(-1000.000000000000000)
         self.tool_probe_x_mpos_dsb.setMaximum(1000.000000000000000)
         self.tool_probe_x_mpos_dsb.setSingleStep(0.100000000000000)
@@ -3849,8 +3832,7 @@ class Ui_MainWindow(object):
         self.tool_probe_z_mpos_dsb.setMinimumSize(QSize(80, 20))
         self.tool_probe_z_mpos_dsb.setMaximumSize(QSize(80, 16777215))
         self.tool_probe_z_mpos_dsb.setFont(font)
-        self.tool_probe_z_mpos_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.tool_probe_z_mpos_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+        self.tool_probe_z_mpos_dsb.setButtonSymbols(QAbstractSpinBox.UpDownArrows)
         self.tool_probe_z_mpos_dsb.setMinimum(-1000.000000000000000)
         self.tool_probe_z_mpos_dsb.setMaximum(1000.000000000000000)
         self.tool_probe_z_mpos_dsb.setSingleStep(0.100000000000000)
@@ -3875,8 +3857,7 @@ class Ui_MainWindow(object):
         self.tool_probe_z_wpos_dsb.setMinimumSize(QSize(80, 20))
         self.tool_probe_z_wpos_dsb.setMaximumSize(QSize(80, 16777215))
         self.tool_probe_z_wpos_dsb.setFont(font)
-        self.tool_probe_z_wpos_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.tool_probe_z_wpos_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+        self.tool_probe_z_wpos_dsb.setButtonSymbols(QAbstractSpinBox.UpDownArrows)
         self.tool_probe_z_wpos_dsb.setMinimum(-1000.000000000000000)
         self.tool_probe_z_wpos_dsb.setMaximum(1000.000000000000000)
         self.tool_probe_z_wpos_dsb.setSingleStep(0.100000000000000)
@@ -3900,10 +3881,10 @@ class Ui_MainWindow(object):
         self.tool_probe_wm_pos_chb.setSizePolicy(sizePolicy3)
         self.tool_probe_wm_pos_chb.setMinimumSize(QSize(150, 20))
         self.tool_probe_wm_pos_chb.setMaximumSize(QSize(150, 20))
-        self.tool_probe_wm_pos_chb.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
+        self.tool_probe_wm_pos_chb.setLayoutDirection(Qt.LeftToRight)
         self.tool_probe_wm_pos_chb.setAutoFillBackground(True)
 
-        self.gridLayout_14.addWidget(self.tool_probe_wm_pos_chb, 1, 4, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout_14.addWidget(self.tool_probe_wm_pos_chb, 1, 4, 1, 1)
 
         self.get_tool_probe_pb = QPushButton(self.jobs_machine_settings_tab)
         self.get_tool_probe_pb.setObjectName(u"get_tool_probe_pb")
@@ -3914,7 +3895,7 @@ class Ui_MainWindow(object):
         self.get_tool_probe_pb.setFont(font)
         self.get_tool_probe_pb.setLocale(QLocale(QLocale.English, QLocale.UnitedKingdom))
 
-        self.gridLayout_14.addWidget(self.get_tool_probe_pb, 2, 4, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout_14.addWidget(self.get_tool_probe_pb, 2, 4, 1, 1)
 
 
         self.horizontalLayout_13.addLayout(self.gridLayout_14)
@@ -3924,7 +3905,7 @@ class Ui_MainWindow(object):
 
         self.line_6 = QFrame(self.jobs_machine_settings_tab)
         self.line_6.setObjectName(u"line_6")
-        self.line_6.setFrameShape(QFrame.Shape.HLine)
+        self.line_6.setFrameShape(QFrame.Shape.VLine)
         self.line_6.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.verticalLayout_5.addWidget(self.line_6)
@@ -3933,7 +3914,7 @@ class Ui_MainWindow(object):
         self.horizontalLayout_15.setObjectName(u"horizontalLayout_15")
         self.gridLayout_15 = QGridLayout()
         self.gridLayout_15.setObjectName(u"gridLayout_15")
-        self.gridLayout_15.setSizeConstraint(QLayout.SizeConstraint.SetDefaultConstraint)
+        self.gridLayout_15.setSizeConstraint(QLayout.SetDefaultConstraint)
         self.tool_change_z_mpos_dsb = QDoubleSpinBox(self.jobs_machine_settings_tab)
         self.tool_change_z_mpos_dsb.setObjectName(u"tool_change_z_mpos_dsb")
         sizePolicy3.setHeightForWidth(self.tool_change_z_mpos_dsb.sizePolicy().hasHeightForWidth())
@@ -3942,8 +3923,7 @@ class Ui_MainWindow(object):
         self.tool_change_z_mpos_dsb.setMaximumSize(QSize(80, 16777215))
         self.tool_change_z_mpos_dsb.setFont(font)
         self.tool_change_z_mpos_dsb.setLocale(QLocale(QLocale.English, QLocale.UnitedKingdom))
-        self.tool_change_z_mpos_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.tool_change_z_mpos_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+        self.tool_change_z_mpos_dsb.setButtonSymbols(QAbstractSpinBox.UpDownArrows)
         self.tool_change_z_mpos_dsb.setMinimum(-1000.000000000000000)
         self.tool_change_z_mpos_dsb.setMaximum(1000.000000000000000)
         self.tool_change_z_mpos_dsb.setSingleStep(0.100000000000000)
@@ -3958,8 +3938,7 @@ class Ui_MainWindow(object):
         self.tool_change_y_mpos_dsb.setMaximumSize(QSize(80, 16777215))
         self.tool_change_y_mpos_dsb.setFont(font)
         self.tool_change_y_mpos_dsb.setLocale(QLocale(QLocale.English, QLocale.UnitedKingdom))
-        self.tool_change_y_mpos_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.tool_change_y_mpos_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+        self.tool_change_y_mpos_dsb.setButtonSymbols(QAbstractSpinBox.UpDownArrows)
         self.tool_change_y_mpos_dsb.setMinimum(-1000.000000000000000)
         self.tool_change_y_mpos_dsb.setMaximum(1000.000000000000000)
         self.tool_change_y_mpos_dsb.setSingleStep(0.100000000000000)
@@ -3974,8 +3953,7 @@ class Ui_MainWindow(object):
         self.tool_change_x_mpos_dsb.setMaximumSize(QSize(80, 16777215))
         self.tool_change_x_mpos_dsb.setFont(font)
         self.tool_change_x_mpos_dsb.setLocale(QLocale(QLocale.English, QLocale.UnitedKingdom))
-        self.tool_change_x_mpos_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.tool_change_x_mpos_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+        self.tool_change_x_mpos_dsb.setButtonSymbols(QAbstractSpinBox.UpDownArrows)
         self.tool_change_x_mpos_dsb.setMinimum(-1000.000000000000000)
         self.tool_change_x_mpos_dsb.setMaximum(1000.000000000000000)
         self.tool_change_x_mpos_dsb.setSingleStep(0.100000000000000)
@@ -4002,7 +3980,7 @@ class Ui_MainWindow(object):
         self.get_tool_change_pb.setFont(font)
         self.get_tool_change_pb.setLocale(QLocale(QLocale.English, QLocale.UnitedKingdom))
 
-        self.gridLayout_15.addWidget(self.get_tool_change_pb, 0, 5, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout_15.addWidget(self.get_tool_change_pb, 0, 5, 1, 1)
 
 
         self.horizontalLayout_15.addLayout(self.gridLayout_15)
@@ -4015,39 +3993,39 @@ class Ui_MainWindow(object):
 
         self.line_8 = QFrame(self.jobs_machine_settings_tab)
         self.line_8.setObjectName(u"line_8")
-        self.line_8.setFrameShape(QFrame.Shape.HLine)
+        self.line_8.setFrameShape(QFrame.Shape.VLine)
         self.line_8.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.gridLayout_13.addWidget(self.line_8, 13, 0, 1, 1)
 
         self.line_15 = QFrame(self.jobs_machine_settings_tab)
         self.line_15.setObjectName(u"line_15")
-        self.line_15.setFrameShape(QFrame.Shape.HLine)
+        self.line_15.setFrameShape(QFrame.Shape.VLine)
         self.line_15.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.gridLayout_13.addWidget(self.line_15, 8, 0, 1, 1)
 
         self.line_9 = QFrame(self.jobs_machine_settings_tab)
         self.line_9.setObjectName(u"line_9")
-        self.line_9.setFrameShape(QFrame.Shape.HLine)
+        self.line_9.setFrameShape(QFrame.Shape.VLine)
         self.line_9.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.gridLayout_13.addWidget(self.line_9, 17, 0, 1, 1)
 
         self.line_7 = QFrame(self.jobs_machine_settings_tab)
         self.line_7.setObjectName(u"line_7")
-        self.line_7.setFrameShape(QFrame.Shape.HLine)
+        self.line_7.setFrameShape(QFrame.Shape.VLine)
         self.line_7.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.gridLayout_13.addWidget(self.line_7, 15, 0, 1, 1)
 
-        self.verticalSpacer_4 = QSpacerItem(20, 10, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+        self.verticalSpacer_4 = QSpacerItem(20, 10, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.gridLayout_13.addItem(self.verticalSpacer_4, 16, 0, 1, 1)
 
         self.line_12 = QFrame(self.jobs_machine_settings_tab)
         self.line_12.setObjectName(u"line_12")
-        self.line_12.setFrameShape(QFrame.Shape.HLine)
+        self.line_12.setFrameShape(QFrame.Shape.VLine)
         self.line_12.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.gridLayout_13.addWidget(self.line_12, 0, 0, 1, 1)
@@ -4055,7 +4033,7 @@ class Ui_MainWindow(object):
         self.verticalLayout_4 = QVBoxLayout()
         self.verticalLayout_4.setSpacing(2)
         self.verticalLayout_4.setObjectName(u"verticalLayout_4")
-        self.verticalLayout_4.setSizeConstraint(QLayout.SizeConstraint.SetFixedSize)
+        self.verticalLayout_4.setSizeConstraint(QLayout.SetDefaultConstraint)
         self.gridLayout_21 = QGridLayout()
         self.gridLayout_21.setObjectName(u"gridLayout_21")
         self.gridLayout_21.setHorizontalSpacing(0)
@@ -4071,7 +4049,7 @@ class Ui_MainWindow(object):
         self.hold_on_probe_chb.setMinimumSize(QSize(150, 0))
         self.hold_on_probe_chb.setMaximumSize(QSize(150, 16777215))
 
-        self.gridLayout_21.addWidget(self.hold_on_probe_chb, 0, 1, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout_21.addWidget(self.hold_on_probe_chb, 0, 1, 1, 1)
 
         self.zeroing_after_probe_chb = QCheckBox(self.jobs_machine_settings_tab)
         self.zeroing_after_probe_chb.setObjectName(u"zeroing_after_probe_chb")
@@ -4080,7 +4058,7 @@ class Ui_MainWindow(object):
         self.zeroing_after_probe_chb.setMinimumSize(QSize(150, 0))
         self.zeroing_after_probe_chb.setMaximumSize(QSize(150, 16777215))
 
-        self.gridLayout_21.addWidget(self.zeroing_after_probe_chb, 0, 2, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout_21.addWidget(self.zeroing_after_probe_chb, 0, 2, 1, 1)
 
 
         self.verticalLayout_4.addLayout(self.gridLayout_21)
@@ -4092,25 +4070,25 @@ class Ui_MainWindow(object):
         self.feedrates_section_la.setObjectName(u"feedrates_section_la")
         self.feedrates_section_la.setFont(font4)
 
-        self.gridLayout_13.addWidget(self.feedrates_section_la, 18, 0, 1, 1, Qt.AlignmentFlag.AlignHCenter|Qt.AlignmentFlag.AlignVCenter)
+        self.gridLayout_13.addWidget(self.feedrates_section_la, 18, 0, 1, 1)
 
         self.line_11 = QFrame(self.jobs_machine_settings_tab)
         self.line_11.setObjectName(u"line_11")
-        self.line_11.setFrameShape(QFrame.Shape.HLine)
+        self.line_11.setFrameShape(QFrame.Shape.VLine)
         self.line_11.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.gridLayout_13.addWidget(self.line_11, 2, 0, 1, 1)
 
         self.line_13 = QFrame(self.jobs_machine_settings_tab)
         self.line_13.setObjectName(u"line_13")
-        self.line_13.setFrameShape(QFrame.Shape.HLine)
+        self.line_13.setFrameShape(QFrame.Shape.VLine)
         self.line_13.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.gridLayout_13.addWidget(self.line_13, 4, 0, 1, 1)
 
         self.line_14 = QFrame(self.jobs_machine_settings_tab)
         self.line_14.setObjectName(u"line_14")
-        self.line_14.setFrameShape(QFrame.Shape.HLine)
+        self.line_14.setFrameShape(QFrame.Shape.VLine)
         self.line_14.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.gridLayout_13.addWidget(self.line_14, 11, 0, 1, 1)
@@ -4124,7 +4102,7 @@ class Ui_MainWindow(object):
         self.verticalLayout_15.setObjectName(u"verticalLayout_15")
         self.line_21 = QFrame(self.alignment_settings_tab)
         self.line_21.setObjectName(u"line_21")
-        self.line_21.setFrameShape(QFrame.Shape.HLine)
+        self.line_21.setFrameShape(QFrame.Shape.VLine)
         self.line_21.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.verticalLayout_15.addWidget(self.line_21)
@@ -4133,11 +4111,11 @@ class Ui_MainWindow(object):
         self.alignment_drill_section_la.setObjectName(u"alignment_drill_section_la")
         self.alignment_drill_section_la.setFont(font4)
 
-        self.verticalLayout_15.addWidget(self.alignment_drill_section_la, 0, Qt.AlignmentFlag.AlignHCenter)
+        self.verticalLayout_15.addWidget(self.alignment_drill_section_la)
 
         self.line_22 = QFrame(self.alignment_settings_tab)
         self.line_22.setObjectName(u"line_22")
-        self.line_22.setFrameShape(QFrame.Shape.HLine)
+        self.line_22.setFrameShape(QFrame.Shape.VLine)
         self.line_22.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.verticalLayout_15.addWidget(self.line_22)
@@ -4163,8 +4141,7 @@ class Ui_MainWindow(object):
         self.alignment_drill_diameter_dsb.setMaximumSize(QSize(252, 16777215))
         self.alignment_drill_diameter_dsb.setFont(font)
         self.alignment_drill_diameter_dsb.setLocale(QLocale(QLocale.English, QLocale.UnitedKingdom))
-        self.alignment_drill_diameter_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.alignment_drill_diameter_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.UpDownArrows)
+        self.alignment_drill_diameter_dsb.setButtonSymbols(QAbstractSpinBox.UpDownArrows)
         self.alignment_drill_diameter_dsb.setMaximum(100000.000000000000000)
         self.alignment_drill_diameter_dsb.setSingleStep(1.000000000000000)
 
@@ -4173,13 +4150,13 @@ class Ui_MainWindow(object):
 
         self.verticalLayout_15.addLayout(self.horizontalLayout_25)
 
-        self.verticalSpacer_10 = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+        self.verticalSpacer_10 = QSpacerItem(20, 40, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.verticalLayout_15.addItem(self.verticalSpacer_10)
 
         self.line_23 = QFrame(self.alignment_settings_tab)
         self.line_23.setObjectName(u"line_23")
-        self.line_23.setFrameShape(QFrame.Shape.HLine)
+        self.line_23.setFrameShape(QFrame.Shape.VLine)
         self.line_23.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.verticalLayout_15.addWidget(self.line_23)
@@ -4188,18 +4165,18 @@ class Ui_MainWindow(object):
         self.alignment_camera_tool_offset_section_la.setObjectName(u"alignment_camera_tool_offset_section_la")
         self.alignment_camera_tool_offset_section_la.setFont(font4)
 
-        self.verticalLayout_15.addWidget(self.alignment_camera_tool_offset_section_la, 0, Qt.AlignmentFlag.AlignHCenter)
+        self.verticalLayout_15.addWidget(self.alignment_camera_tool_offset_section_la)
 
         self.line_24 = QFrame(self.alignment_settings_tab)
         self.line_24.setObjectName(u"line_24")
-        self.line_24.setFrameShape(QFrame.Shape.HLine)
+        self.line_24.setFrameShape(QFrame.Shape.VLine)
         self.line_24.setFrameShadow(QFrame.Shadow.Sunken)
 
         self.verticalLayout_15.addWidget(self.line_24)
 
         self.gridLayout_17 = QGridLayout()
         self.gridLayout_17.setObjectName(u"gridLayout_17")
-        self.gridLayout_17.setSizeConstraint(QLayout.SizeConstraint.SetDefaultConstraint)
+        self.gridLayout_17.setSizeConstraint(QLayout.SetDefaultConstraint)
         self.tool_camera_offset_la = QLabel(self.alignment_settings_tab)
         self.tool_camera_offset_la.setObjectName(u"tool_camera_offset_la")
         sizePolicy3.setHeightForWidth(self.tool_camera_offset_la.sizePolicy().hasHeightForWidth())
@@ -4219,8 +4196,7 @@ class Ui_MainWindow(object):
         self.y_tool_camera_offset_dsb.setMaximumSize(QSize(80, 16777215))
         self.y_tool_camera_offset_dsb.setFont(font)
         self.y_tool_camera_offset_dsb.setLocale(QLocale(QLocale.English, QLocale.UnitedKingdom))
-        self.y_tool_camera_offset_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.y_tool_camera_offset_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+        self.y_tool_camera_offset_dsb.setButtonSymbols(QAbstractSpinBox.UpDownArrows)
         self.y_tool_camera_offset_dsb.setMinimum(-1000.000000000000000)
         self.y_tool_camera_offset_dsb.setMaximum(1000.000000000000000)
         self.y_tool_camera_offset_dsb.setSingleStep(0.100000000000000)
@@ -4236,7 +4212,7 @@ class Ui_MainWindow(object):
         self.get_tool_camera_offset_pb.setFont(font)
         self.get_tool_camera_offset_pb.setLocale(QLocale(QLocale.English, QLocale.UnitedKingdom))
 
-        self.gridLayout_17.addWidget(self.get_tool_camera_offset_pb, 0, 4, 1, 1, Qt.AlignmentFlag.AlignHCenter)
+        self.gridLayout_17.addWidget(self.get_tool_camera_offset_pb, 0, 4, 1, 1)
 
         self.x_tool_camera_offset_dsb = QDoubleSpinBox(self.alignment_settings_tab)
         self.x_tool_camera_offset_dsb.setObjectName(u"x_tool_camera_offset_dsb")
@@ -4246,8 +4222,7 @@ class Ui_MainWindow(object):
         self.x_tool_camera_offset_dsb.setMaximumSize(QSize(80, 16777215))
         self.x_tool_camera_offset_dsb.setFont(font)
         self.x_tool_camera_offset_dsb.setLocale(QLocale(QLocale.English, QLocale.UnitedKingdom))
-        self.x_tool_camera_offset_dsb.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.x_tool_camera_offset_dsb.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+        self.x_tool_camera_offset_dsb.setButtonSymbols(QAbstractSpinBox.UpDownArrows)
         self.x_tool_camera_offset_dsb.setMinimum(-1000.000000000000000)
         self.x_tool_camera_offset_dsb.setMaximum(1000.000000000000000)
         self.x_tool_camera_offset_dsb.setSingleStep(0.100000000000000)
@@ -4257,7 +4232,7 @@ class Ui_MainWindow(object):
 
         self.verticalLayout_15.addLayout(self.gridLayout_17)
 
-        self.verticalSpacer_11 = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+        self.verticalSpacer_11 = QSpacerItem(20, 40, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
 
         self.verticalLayout_15.addItem(self.verticalSpacer_11)
 
@@ -4313,7 +4288,7 @@ class Ui_MainWindow(object):
         MainWindow.setCentralWidget(self.central_widget)
         self.menubar = QMenuBar(MainWindow)
         self.menubar.setObjectName(u"menubar")
-        self.menubar.setGeometry(QRect(0, 0, 1160, 33))
+        self.menubar.setGeometry(QRect(0, 0, 1160, 22))
         self.menuFile = QMenu(self.menubar)
         self.menuFile.setObjectName(u"menuFile")
         self.menuFile.setFont(font)
@@ -4321,7 +4296,7 @@ class Ui_MainWindow(object):
         self.menuConsole.setObjectName(u"menuConsole")
         self.menu_set_level = QMenu(self.menuConsole)
         self.menu_set_level.setObjectName(u"menu_set_level")
-        self.menu_set_level.setInputMethodHints(Qt.InputMethodHint.ImhNone)
+        self.menu_set_level.setInputMethodHints(Qt.ImhNone)
         self.menuAbout = QMenu(self.menubar)
         self.menuAbout.setObjectName(u"menuAbout")
         MainWindow.setMenuBar(self.menubar)
@@ -4427,7 +4402,7 @@ class Ui_MainWindow(object):
 
         self.retranslateUi(MainWindow)
 
-        self.main_tab_widget.setCurrentIndex(1)
+        self.main_tab_widget.setCurrentIndex(3)
         self.prepare_widget.setCurrentIndex(1)
         self.jobs_sw.setCurrentIndex(0)
         self.ctrl_tab_widget.setCurrentIndex(1)
@@ -4436,7 +4411,7 @@ class Ui_MainWindow(object):
         self.xy_step_cb.setCurrentIndex(3)
         self.z_step_cb_2.setCurrentIndex(3)
         self.xy_step_cb_2.setCurrentIndex(3)
-        self.settings_sub_tab.setCurrentIndex(2)
+        self.settings_sub_tab.setCurrentIndex(0)
 
 
         QMetaObject.connectSlotsByName(MainWindow)
@@ -4817,6 +4792,9 @@ class Ui_MainWindow(object):
         self.label_17.setText(QCoreApplication.translate("MainWindow", u"Error/STD_Deviation", None))
         self.label_18.setText(QCoreApplication.translate("MainWindow", u"No value available", None))
         self.main_tab_widget.setTabText(self.main_tab_widget.indexOf(self.align_tab), QCoreApplication.translate("MainWindow", u"ALIGN", None))
+        self.allignment_drill_diameter_la_2.setText(QCoreApplication.translate("MainWindow", u"Serial Error Warning Threshold", None))
+        self.allignment_drill_diameter_la_3.setText(QCoreApplication.translate("MainWindow", u"Serial Error Critical Threshold", None))
+        self.layer_colors_section_la.setText(QCoreApplication.translate("MainWindow", u"LAYER COLORS", None))
         self.top_layer_color_pb.setText(QCoreApplication.translate("MainWindow", u"TOP LAYER COLOR", None))
         self.bottom_layer_color_pb.setText(QCoreApplication.translate("MainWindow", u"BOTTOM LAYER COLOR", None))
         self.bottom_layer_color_la.setText("")
@@ -4829,7 +4807,7 @@ class Ui_MainWindow(object):
         self.drill_layer_color_la.setText("")
         self.nc_top_layer_color_la.setText("")
         self.nc_bottom_layer_color_la.setText("")
-        self.layer_colors_section_la.setText(QCoreApplication.translate("MainWindow", u"LAYER COLORS", None))
+        self.layer_colors_section_la_2.setText(QCoreApplication.translate("MainWindow", u"SERIAL SETTINGS", None))
         self.settings_sub_tab.setTabText(self.settings_sub_tab.indexOf(self.application_settings_tab), QCoreApplication.translate("MainWindow", u"Application Settings", None))
         self.x_axis_la.setText(QCoreApplication.translate("MainWindow", u"X (top-down mirror)", None))
         self.x_la_2.setText(QCoreApplication.translate("MainWindow", u"Y (left-right mirror)", None))

--- a/tests/unit/test_serial_manager.py
+++ b/tests/unit/test_serial_manager.py
@@ -18,7 +18,7 @@ class TestSerialManager:
         # Set up signal spy
         with qtbot.waitSignal(serial_manager.open_port_s, timeout=1000) as blocker:
             serial_manager.open_port("COM1", 115200)
-        
+
         # Verify results
         assert blocker.args == [True]
         serial_manager.serial_port.setBaudRate.assert_called_once_with(115200)
@@ -50,25 +50,120 @@ class TestSerialManager:
         mock_data = mocker.Mock()
         mock_data.data = mocker.Mock(return_value=b"ok\n")
         serial_manager.serial_port.readAll = mocker.Mock(return_value=mock_data)
-        
+
         # Test receiving data
         serial_manager.receive()
         assert serial_manager.residual_string == ""  # Should be cleared after processing
 
-    def test_connection_error(self, serial_manager, caplog):
-        """Test handling errors - verify errors are logged but port stays open"""
-        # Setup error conditions
+    def test_connection_error_below_warning_threshold(self, serial_manager, qtbot, caplog):
+        """Test error handling below warning threshold - error should not be logged"""
         error_string = "Test Error Message"
         serial_manager.serial_port.error.return_value = QSerialPort.ResourceError
         serial_manager.serial_port.errorString.return_value = error_string
 
-        # Trigger error
+        # Trigger error once (below warning threshold of 3)
         serial_manager.serial_error_manager()
 
-        # Verify error was logged but port stays open
-        assert "ResourceError" in caplog.text
-        assert error_string in caplog.text
-        assert serial_manager.serial_port.isOpen()
+        # Should not emit console update signal or log at error level yet
+        assert serial_manager._consecutive_errors == 1
+        # Should not log the error yet (below threshold)
+        assert "Serial error:" not in caplog.text
+
+    def test_connection_error_at_warning_threshold(self, serial_manager, qtbot, caplog):
+        """Test error handling at warning threshold - should log warning"""
+        error_string = "Test Error Message"
+        serial_manager.serial_port.error.return_value = QSerialPort.ResourceError
+        serial_manager.serial_port.errorString.return_value = error_string
+
+        # Simulate reaching warning threshold (3 errors)
+        with qtbot.waitSignal(serial_manager.update_console_text_s, timeout=1000) as blocker:
+            for _ in range(3):
+                serial_manager.serial_error_manager()
+
+        # Should have logged warning and emitted console signal
+        assert serial_manager._consecutive_errors == 3
+        assert "Serial error:" in caplog.text or "Warning:" in blocker.args[0]
+
+    def test_connection_error_at_critical_threshold(self, serial_manager, qtbot, caplog):
+        """Test error handling at critical threshold - should close port"""
+        error_string = "Test Error Message"
+        serial_manager.serial_port.error.return_value = QSerialPort.ResourceError
+        serial_manager.serial_port.errorString.return_value = error_string
+
+        # Simulate reaching critical threshold (10 errors)
+        with qtbot.waitSignal(serial_manager.close_for_error_s, timeout=1000) as blocker:
+            for _ in range(10):
+                serial_manager.serial_error_manager()
+
+        # Should have logged critical error and emitted close signal
+        assert serial_manager._consecutive_errors == 10
+        assert "Critical error:" in caplog.text
+
+    def test_error_type_change_resets_counter(self, serial_manager):
+        """Test that changing error type resets the consecutive error counter"""
+        # Simulate first error type
+        serial_manager.serial_port.error.return_value = QSerialPort.ResourceError
+        serial_manager.serial_port.errorString.return_value = "Resource Error"
+        serial_manager.serial_error_manager()
+        serial_manager.serial_error_manager()
+
+        assert serial_manager._consecutive_errors == 2
+        assert serial_manager._last_error_type == QSerialPort.ResourceError
+
+        # Change to different error type
+        serial_manager.serial_port.error.return_value = QSerialPort.TimeoutError
+        serial_manager.serial_port.errorString.return_value = "Timeout Error"
+        serial_manager.serial_error_manager()
+
+        # Counter should be reset to 1 (for the new error type)
+        assert serial_manager._consecutive_errors == 1
+        assert serial_manager._last_error_type == QSerialPort.TimeoutError
+
+    def test_no_error_resets_counters(self, serial_manager):
+        """Test that no error state resets the error counters"""
+        # Simulate some errors
+        serial_manager.serial_port.error.return_value = QSerialPort.ResourceError
+        serial_manager.serial_port.errorString.return_value = "Resource Error"
+        serial_manager.serial_error_manager()
+        serial_manager.serial_error_manager()
+
+        assert serial_manager._consecutive_errors == 2
+
+        # Now simulate no error
+        serial_manager.serial_port.error.return_value = QSerialPort.NoError
+        serial_manager.serial_error_manager()
+
+        # Counters should be reset
+        assert serial_manager._consecutive_errors == 0
+        assert serial_manager._last_error_type is None
+
+    def test_reset_error_count_method(self, serial_manager):
+        """Test the reset_error_count method"""
+        # Simulate some errors
+        serial_manager._consecutive_errors = 5
+        serial_manager._last_error_type = QSerialPort.ResourceError
+
+        # Call reset method
+        serial_manager.reset_error_count()
+
+        # Should be reset
+        assert serial_manager._consecutive_errors == 0
+        assert serial_manager._last_error_type is None
+
+    def test_close_port_resets_error_count(self, serial_manager):
+        """Test that closing port resets error count"""
+        # Simulate some errors
+        serial_manager._consecutive_errors = 5
+        serial_manager._last_error_type = QSerialPort.ResourceError
+        serial_manager.serial_port.portName.return_value = "COM1"
+
+        # Close port
+        serial_manager.close_port()
+
+        # Error count should be reset
+        assert serial_manager._consecutive_errors == 0
+        assert serial_manager._last_error_type is None
+        serial_manager.serial_port.close.assert_called_once()
 
     def test_get_port_list(self, serial_manager, mocker, qtbot):
         """Test getting available ports list"""

--- a/tests/unit/test_settings_manager.py
+++ b/tests/unit/test_settings_manager.py
@@ -8,19 +8,19 @@ class TestAppSettingsHandler:
     def mock_main_window(self, mocker):
         """Fixture for mocked main window with all required attributes"""
         mock_main_win = mocker.Mock()
-        
+
         # Mock window position and geometry
         mock_pos = mocker.Mock()
         mock_pos.x.return_value = 200
         mock_pos.y.return_value = 200
         mock_main_win.pos.return_value = mock_pos
-        
+
         mock_geo = mocker.Mock()
         mock_geo.width.return_value = 1160
         mock_geo.height.return_value = 720
         mock_main_win.normalGeometry.return_value = mock_geo
         mock_main_win.isMaximized.return_value = False
-        
+
         # Mock UI elements
         mock_ui = mocker.Mock()
         mock_ui.main_tab_widget.currentIndex.return_value = 0
@@ -35,7 +35,7 @@ class TestAppSettingsHandler:
         mock_ui.flip_horizontally_tb.isChecked.return_value = False
         mock_ui.flip_vertically_tb.isChecked.return_value = False
         mock_main_win.ui = mock_ui
-        
+
         return mock_main_win
 
     @pytest.fixture
@@ -44,10 +44,10 @@ class TestAppSettingsHandler:
         # Create a temporary config directory for this test
         config_folder = tmp_path / "configurations"
         config_folder.mkdir()
-        
+
         # Set local path to the temporary directory
         mock_main_window.local_path = str(tmp_path)
-        
+
         return AppSettingsHandler(str(config_folder), mock_main_window)
 
     def test_load_config(self, app_settings_handler):
@@ -63,22 +63,22 @@ class TestAppSettingsHandler:
         config_dir = tmp_path / "test_save" / "configurations"
         config_dir.mkdir(parents=True)
         app_settings_handler.app_config_path = str(config_dir / "app_config.ini")
-        
+
         # First save default settings
         app_settings_handler.restore_app_settings()
-        
+
         # Modify default settings through main window mock
         app_settings_handler.main_win.ui.actionHide_Show_Align_Tab.isChecked.return_value = True
         app_settings_handler.main_win.ui.actionSettings_Preferences.isChecked.return_value = True
         app_settings_handler.main_win.ui.flip_horizontally_tb.isChecked.return_value = True
-        
+
         # Write settings
         app_settings_handler.write_all_app_settings()
-        
+
         # Create a new instance with the same config path
         new_settings = AppSettingsHandler(str(config_dir), app_settings_handler.main_win)
         new_settings.read_all_app_settings()
-        
+
         # Verify settings were saved and read back correctly
         assert new_settings.align_tab_visibility == True
         assert new_settings.settings_tab_visibility == True
@@ -90,17 +90,17 @@ class TestAppSettingsHandler:
         test_root = tmp_path / "test_invalid"
         test_root.mkdir()
         mock_main_window.local_path = str(test_root)  # Set local path to our test directory
-        
+
         # Create new instance with non-existent config path
         test_config_dir = test_root / "configurations"
         new_settings = AppSettingsHandler(str(test_config_dir), mock_main_window)
-        
+
         # Before reading settings, directory should not exist
         assert not os.path.exists(test_config_dir)
-        
+
         # Reading settings should create directory and default config
         new_settings.read_all_app_settings()
-        
+
         # Verify directory and config file were created
         assert os.path.exists(test_config_dir)
         assert os.path.exists(os.path.join(test_config_dir, "app_config.ini"))
@@ -116,11 +116,65 @@ class TestAppSettingsHandler:
             'align_tab_visibility': True,
             'console_visibility': True
         }
-        
+
         # Update settings
         for attr, value in test_values.items():
             setattr(app_settings_handler, attr, value)
-        
+
         # Verify updates
         for attr, value in test_values.items():
             assert getattr(app_settings_handler, attr) == value
+
+    def test_serial_error_threshold_defaults(self, app_settings_handler):
+        """Test that serial error thresholds are initialized with default values"""
+        assert app_settings_handler.serial_error_warning_threshold == app_settings_handler.SERIAL_ERROR_WARNING_THRESHOLD_DEFAULT
+        assert app_settings_handler.serial_error_critical_threshold == app_settings_handler.SERIAL_ERROR_CRITICAL_THRESHOLD_DEFAULT
+        assert app_settings_handler.serial_error_warning_threshold == 3
+        assert app_settings_handler.serial_error_critical_threshold == 10
+
+    def test_serial_error_threshold_save_and_load(self, app_settings_handler, tmp_path):
+        """Test saving and loading serial error thresholds"""
+        # Set up test config directory
+        config_dir = tmp_path / "test_thresholds" / "configurations"
+        config_dir.mkdir(parents=True)
+        app_settings_handler.app_config_path = str(config_dir / "app_config.ini")
+
+        # Modify thresholds
+        app_settings_handler.serial_error_warning_threshold = 5
+        app_settings_handler.serial_error_critical_threshold = 15
+
+        # Save settings
+        app_settings_handler.write_all_app_settings()
+
+        # Create new instance and load settings
+        new_settings = AppSettingsHandler(str(config_dir), app_settings_handler.main_win)
+        new_settings.read_all_app_settings()
+
+        # Verify modified thresholds were saved and loaded
+        assert new_settings.serial_error_warning_threshold == 5
+        assert new_settings.serial_error_critical_threshold == 15
+
+    def test_serial_error_threshold_restore_defaults(self, app_settings_handler, tmp_path):
+        """Test restoring default serial error thresholds"""
+        # Set up test config directory
+        config_dir = tmp_path / "test_restore_thresholds" / "configurations"
+        config_dir.mkdir(parents=True)
+        app_settings_handler.app_config_path = str(config_dir / "app_config.ini")
+
+        # Modify thresholds
+        app_settings_handler.serial_error_warning_threshold = 7
+        app_settings_handler.serial_error_critical_threshold = 20
+
+        # Save modified settings
+        app_settings_handler.write_all_app_settings()
+
+        # Restore defaults
+        app_settings_handler.restore_app_settings()
+
+        # Create new instance and load restored settings
+        new_settings = AppSettingsHandler(str(config_dir), app_settings_handler.main_win)
+        new_settings.read_all_app_settings()
+
+        # Verify thresholds are restored to defaults
+        assert new_settings.serial_error_warning_threshold == app_settings_handler.SERIAL_ERROR_WARNING_THRESHOLD_DEFAULT
+        assert new_settings.serial_error_critical_threshold == app_settings_handler.SERIAL_ERROR_CRITICAL_THRESHOLD_DEFAULT

--- a/tests/unit/test_settings_manager.py
+++ b/tests/unit/test_settings_manager.py
@@ -178,3 +178,133 @@ class TestAppSettingsHandler:
         # Verify thresholds are restored to defaults
         assert new_settings.serial_error_warning_threshold == app_settings_handler.SERIAL_ERROR_WARNING_THRESHOLD_DEFAULT
         assert new_settings.serial_error_critical_threshold == app_settings_handler.SERIAL_ERROR_CRITICAL_THRESHOLD_DEFAULT
+
+    def test_serial_error_threshold_validation_zero_values(self, app_settings_handler, tmp_path):
+        """Test that zero thresholds are accepted - valid edge case for closing on first error"""
+        # Set up test config directory
+        config_dir = tmp_path / "test_zero_thresholds" / "configurations"
+        config_dir.mkdir(parents=True)
+        app_settings_handler.app_config_path = str(config_dir / "app_config.ini")
+
+        # Manually write config with zero values (now valid)
+        import configparser
+        config = configparser.ConfigParser()
+        config["GENERAL"] = {
+            "serial_error_warning_threshold": "0",
+            "serial_error_critical_threshold": "0"
+        }
+        config_dir.mkdir(parents=True, exist_ok=True)
+        with open(str(config_dir / "app_config.ini"), "w") as f:
+            config.write(f)
+
+        # Load settings - should accept (0, 0) as valid
+        new_settings = AppSettingsHandler(str(config_dir), app_settings_handler.main_win)
+        new_settings.read_all_app_settings()
+
+        # Verify thresholds are (0, 0)
+        assert new_settings.serial_error_warning_threshold == 0
+        assert new_settings.serial_error_critical_threshold == 0
+
+    def test_serial_error_threshold_validation_negative_values(self, app_settings_handler, tmp_path):
+        """Test that negative thresholds are rejected and reset to defaults"""
+        # Set up test config directory
+        config_dir = tmp_path / "test_negative_thresholds" / "configurations"
+        config_dir.mkdir(parents=True)
+        app_settings_handler.app_config_path = str(config_dir / "app_config.ini")
+
+        # Manually write invalid config with negative values
+        import configparser
+        config = configparser.ConfigParser()
+        config["GENERAL"] = {
+            "serial_error_warning_threshold": "-5",
+            "serial_error_critical_threshold": "-10"
+        }
+        config_dir.mkdir(parents=True, exist_ok=True)
+        with open(str(config_dir / "app_config.ini"), "w") as f:
+            config.write(f)
+
+        # Load settings - should validate and reset to defaults
+        new_settings = AppSettingsHandler(str(config_dir), app_settings_handler.main_win)
+        new_settings.read_all_app_settings()
+
+        # Verify thresholds were reset to defaults
+        assert new_settings.serial_error_warning_threshold == new_settings.SERIAL_ERROR_WARNING_THRESHOLD_DEFAULT
+        assert new_settings.serial_error_critical_threshold == new_settings.SERIAL_ERROR_CRITICAL_THRESHOLD_DEFAULT
+
+    def test_serial_error_threshold_validation_invalid_order(self, app_settings_handler, tmp_path):
+        """Test that invalid threshold order (warning > critical) is rejected and reset to defaults"""
+        # Set up test config directory
+        config_dir = tmp_path / "test_invalid_order_thresholds" / "configurations"
+        config_dir.mkdir(parents=True)
+        app_settings_handler.app_config_path = str(config_dir / "app_config.ini")
+
+        # Manually write invalid config with warning > critical
+        import configparser
+        config = configparser.ConfigParser()
+        config["GENERAL"] = {
+            "serial_error_warning_threshold": "10",
+            "serial_error_critical_threshold": "5"
+        }
+        config_dir.mkdir(parents=True, exist_ok=True)
+        with open(str(config_dir / "app_config.ini"), "w") as f:
+            config.write(f)
+
+        # Load settings - should validate and reset to defaults
+        new_settings = AppSettingsHandler(str(config_dir), app_settings_handler.main_win)
+        new_settings.read_all_app_settings()
+
+        # Verify thresholds were reset to defaults
+        assert new_settings.serial_error_warning_threshold == new_settings.SERIAL_ERROR_WARNING_THRESHOLD_DEFAULT
+        assert new_settings.serial_error_critical_threshold == new_settings.SERIAL_ERROR_CRITICAL_THRESHOLD_DEFAULT
+
+    def test_serial_error_threshold_equal_non_zero_values(self, app_settings_handler, tmp_path):
+        """Test that equal non-zero thresholds (5, 5) are allowed - skip warning phase"""
+        # Set up test config directory
+        config_dir = tmp_path / "test_equal_non_zero_thresholds" / "configurations"
+        config_dir.mkdir(parents=True)
+        app_settings_handler.app_config_path = str(config_dir / "app_config.ini")
+
+        # Manually write config with equal non-zero values
+        import configparser
+        config = configparser.ConfigParser()
+        config["GENERAL"] = {
+            "serial_error_warning_threshold": "5",
+            "serial_error_critical_threshold": "5"
+        }
+        config_dir.mkdir(parents=True, exist_ok=True)
+        with open(str(config_dir / "app_config.ini"), "w") as f:
+            config.write(f)
+
+        # Load settings - should accept (5, 5) as valid
+        new_settings = AppSettingsHandler(str(config_dir), app_settings_handler.main_win)
+        new_settings.read_all_app_settings()
+
+        # Verify thresholds are (5, 5)
+        assert new_settings.serial_error_warning_threshold == 5
+        assert new_settings.serial_error_critical_threshold == 5
+
+    def test_serial_error_threshold_valid_with_zero_warning(self, app_settings_handler, tmp_path):
+        """Test that (0, 10) is valid - log warning on first error, close on 10th"""
+        # Set up test config directory
+        config_dir = tmp_path / "test_zero_warning_threshold" / "configurations"
+        config_dir.mkdir(parents=True)
+        app_settings_handler.app_config_path = str(config_dir / "app_config.ini")
+
+        # Manually write config with (0, 10)
+        import configparser
+        config = configparser.ConfigParser()
+        config["GENERAL"] = {
+            "serial_error_warning_threshold": "0",
+            "serial_error_critical_threshold": "10"
+        }
+        config_dir.mkdir(parents=True, exist_ok=True)
+        with open(str(config_dir / "app_config.ini"), "w") as f:
+            config.write(f)
+
+        # Load settings - should accept (0, 10) as valid
+        new_settings = AppSettingsHandler(str(config_dir), app_settings_handler.main_win)
+        new_settings.read_all_app_settings()
+
+        # Verify thresholds are (0, 10)
+        assert new_settings.serial_error_warning_threshold == 0
+        assert new_settings.serial_error_critical_threshold == 10


### PR DESCRIPTION
In case of serial error the previous behavior was to give an error continuously for every error received. 
This was due to the fact that we want to tolerate a certain amount of errors that could be due to an imperfect or disturbed connection.
The continuous logging of this error is annoying in case the connection is lost.
In order to avoid this we added a settable critical error threshold, that triggers when a given amount of consecutive serial errors are received. If this occurs, an error is logged and the serial port is closed.

A warning error threshold has also been added as setting, if the number of consecutive serial errors is greater than this threshold warning messages are logged up to when the critical threshold is exceeded.

Both the threshold shall be equal or greater than zero, and the warning threshold shall be equal or lesser than the critical threshold. 
If the threshold are equal the critical error behavior prevails.
If the warning threshold is zero all errors are logged up to the critical threshold.
If the critical threshold is zero, the first error triggers the error closing the serial connection.